### PR TITLE
docs(discovery): design critique and revised workflow

### DIFF
--- a/.planning/discovery-design/01-via-negativa.md
+++ b/.planning/discovery-design/01-via-negativa.md
@@ -1,0 +1,95 @@
+# Via Negativa Analysis — Discovery Workflow Design
+
+> **Date:** 2026-04-08
+> **Question:** What can we remove from the design and still have a useful v1 discovery workflow?
+> **Context:** The previous epic pipeline died from over-engineering and deadlocking. This design has 8 source adapters, 4 interaction modes, 3 investigation depths, evidence quality assessment, two-step synthesis, facet decomposition, 3 deferred capture mechanisms, content hash change detection, raw result immutability, confidence scoring, cross-scope promotion, and more.
+
+## Subtraction Candidates (CUT from v1)
+
+### 4 interaction modes (standard/batch/text/analyse)
+Remove because this is designing a preferences system before the tool exists. Every mode is just a prompt variation — if the user wants batch questions, they'll say "give me several at once." Eliminates an entire configuration axis and the code to support it. Just have good conversational intake.
+
+### Assumptions mode as a separate mode
+Remove because it's another mode toggle. A good intake step naturally proposes what it knows and asks the user to correct. That IS assumptions mode — it doesn't need a name or a switch. Removes a branching path from Step 1.
+
+### Facet decomposition (obsidian-personal pattern)
+Remove because it adds a planning-before-planning step. "Break gaps into facets, dispatch facets to adapters" is the obsidian-personal pipeline's job tracking architecture leaking into a Claude Code skill. Claude can just research the gaps. It doesn't need a formal facet decomposition layer to do targeted searches. Eliminates an entire abstraction layer between "here are the gaps" and "go research them."
+
+### 8 research type heuristics table
+Remove because the tool "selects the appropriate type based on the gap" — which means Claude reads the gap and decides how to research it. That's what Claude already does. Labelling it "deep-dive" vs "technical" vs "landscape" adds taxonomy without changing behaviour. Removes a classification system that exists only in the design doc.
+
+### 3 investigation depth levels (quick verify/standard/deep)
+Remove because depth is emergent from the question, not a pre-selected tier. "What's Cassandra's consistency model?" naturally gets a quick answer. "Should we replace PostgreSQL with Cassandra?" naturally goes deep. Claude doesn't need a depth selector. Removes a configuration axis that Claude will ignore in practice.
+
+### Evidence quality assessment (richness/agreement/coverage) with confidence scoring
+Remove because this is quality infrastructure for a system that doesn't exist yet. You cannot assess "richness" or "agreement" programmatically in v1 — Claude will read the results and judge quality as part of synthesis. Formal scoring adds false precision. Eliminates a scoring framework that would either be hand-waved by the LLM or require substantial tooling to be meaningful.
+
+### Two-step synthesis (per-facet extraction then reconciliation)
+Remove because it depends on the facet decomposition you're also cutting. Without formal facets, synthesis is: Claude reads all the research results and writes a coherent summary. That's one step. The two-step pattern is valuable in obsidian-personal where you have database-stored results from 6 independent adapters. In a Claude Code skill where everything is in context, it's overhead. Synthesis becomes "write the output" instead of "extract per facet, then reconcile."
+
+### Raw result immutability + provenance tracking
+Remove because flat markdown files in `.planning/` are already immutable-enough (git tracks history). Formal provenance tracking (which adapter produced what, content hashes, re-synthesis without modifying raw results) is database thinking applied to a directory of markdown files. Results are just files. Git is your provenance.
+
+### Content hash change detection (SHA256)
+Remove because this is an optimisation for a workflow that runs rarely (the doc says project discovery is "rare" and epic discovery is "ad hoc"). Optimising for cache hits on a rarely-run process is premature. Removes a caching mechanism for something that doesn't need caching.
+
+### Parallel dispatch with 2-second polling and 10-minute timeout
+Remove because this is the obsidian-personal job queue architecture. In a Claude Code skill, "parallel" means spawning sub-agents with the Agent tool — Claude Code handles the orchestration. You don't need to build a polling loop. Eliminates process management code that Claude Code already provides.
+
+### Seeds with trigger conditions + Notes (zero-friction capture) as separate mechanisms
+Remove because you already have a "Deferred" section in DISCOVERY.md. Seeds with auto-surfacing trigger conditions are a feature for a mature system, not v1. Notes are just text. The user has a text editor. Collapses 3 deferred capture mechanisms into 1 (the Deferred section that already exists in the output format).
+
+### Cross-scope promotion
+Remove because it's a v2 convenience. If epic discovery produces generalisable knowledge, the user can move the file. An automated "promote to project level?" prompt is nice-to-have, not essential. Removes a feature that sounds useful but adds a branching path to every epic discovery session.
+
+### `<claude_context>` blocks
+Remove because the planner is Claude. Claude can read prose. XML blocks for "machine-readable context" add formatting overhead without changing what the planner actually does — reads the discovery doc and plans accordingly. The planner doesn't parse XML; it reads text. Simplifies output format. Findings are just written clearly.
+
+### Frontmatter schema bloat (confidence/facets/sources fields)
+Remove most of it. Keep `epic`, `title`, `discovered` (date). The rest (`confidence`, `facets`, `sources` list) is metadata that nothing consumes. Frontmatter becomes 3 fields instead of 8.
+
+### Extractability constraints ("no GTS-specific imports")
+Remove as a design constraint for v1. Build it for GTS. If it's good, extracting it later is trivial — it's a Claude Code skill, not a compiled binary. Designing for extraction now constrains implementation choices without delivering value. Frees you to use GTS conventions, paths, and patterns without worrying about portability.
+
+### Adapter category taxonomy (5 categories)
+Remove the taxonomy. You have adapters. Some search, some synthesise, some do both. The 5-category classification is a design doc artefact that doesn't change how they're called. Adapters are just "sources" without a classification hierarchy.
+
+### Staleness detection (90-day flag)
+Remove because it's premature UX polish. The user will know if prior knowledge is stale — they're the one who wrote it or read it. Removes a date-checking mechanism for something a human already does.
+
+## Keep (Passed the Test)
+
+- **7-step workflow structure** — this IS the design. The irreducible sequence of knowledge work. Steps can be lighter, but the flow is correct.
+- **Two entry points** — "same workflow, different scope" is the core insight.
+- **Prior knowledge check (Step 2)** — genuinely novel and valuable. Saves real time and tokens.
+- **Gap identification (Step 3)** — "what specifically do we not know?" is the highest-leverage question.
+- **Decision categorisation (locked/deferred/discretion)** — directly solves agents re-litigating decisions during planning. High-value, low-complexity.
+- **Source adapters (the concept, not 8 of them)** — but 2-3 for v1, not 8.
+- **Thinking models in Step 5** — already built (taches `/consider:*`). Zero implementation cost.
+- **DISCOVERY.md output format** — good output schema (Domain, Findings, Decisions, Code Context, Unknowns).
+- **Hard gate after enrichment** — necessary state transition.
+- **Flat markdown storage** — absolutely correct.
+- **Deferred section in DISCOVERY.md** — the single deferred capture mechanism.
+
+## After Subtraction — v1 Shape
+
+A 7-step discovery workflow as a Claude Code skill (pure prompt, no scripts). Two entry points. Conversational intake without mode selection. Prior knowledge check against `.planning/` and wiki. Gap identification as specific questions. Investigation using 2-3 adapters (WebSearch + WebFetch as baseline, Brave Search as the one external adapter for v1). Analysis using existing taches thinking models. Single-pass synthesis into DISCOVERY.md. Enrichment of the GitHub issue.
+
+Adapter count: 8 → 3 for v1:
+1. **WebSearch** (built-in, zero setup)
+2. **WebFetch** (built-in, zero setup)
+3. **Brave Search** (one API key, optional)
+
+Perplexity and Gemini adapters are v2 — add when the basic workflow is proven.
+
+## What to Say No To (Future)
+
+- Adapter quality evaluation frameworks
+- A/B comparison infrastructure for adapters
+- Session management / handoff for long discoveries
+- Standalone investigation tool (`/investigate`)
+- Any form of job queue, polling loop, or process management
+- Programmatic confidence scoring
+- Any storage more complex than "write a markdown file"
+- Re-synthesis without modifying raw results
+- Automated seed surfacing at milestone boundaries

--- a/.planning/discovery-design/02-first-principles.md
+++ b/.planning/discovery-design/02-first-principles.md
@@ -1,0 +1,76 @@
+# First Principles Analysis — Discovery Workflow Design
+
+> **Date:** 2026-04-08
+> **Question:** What is the irreducible core of pre-planning knowledge work for a software project?
+> **Context:** Post via-negativa pass. 16 features already cut. Examining whether the remaining 7-step structure itself has inherited assumptions from GSD/taches/Superpowers/obsidian-personal.
+
+## Assumptions Challenged
+
+### "Discovery is a 7-step sequential workflow"
+**Partially true.** The steps are logical, but the sequence is inherited from GSD's phase model. In practice, research is iterative — read something, realise a gap, search, read more, revise understanding. The 7-step sequence linearises what is actually a loop. Steps are a useful prompting scaffold, not a runtime execution order.
+
+### "There are two distinct scopes (project vs epic)"
+**Partially true.** Project discovery is exploratory and divergent ("what should we build?"). Epic discovery is convergent ("how should we build this specific thing?"). Same workflow forces a divergent activity into a convergent structure, or vice versa. Project discovery might just be a conversation; epic discovery is a workflow.
+
+### "You need a prior knowledge check as an explicit step"
+**True, but not as a step.** Claude naturally checks context before going external. Making it explicit improves outcomes because it makes the check *visible* to the user and creates a gate ("is this enough?"). It's a gate, not a step.
+
+### "Gap identification must happen before investigation"
+**Partially true.** You often don't know what you don't know until you start looking. First search result reveals gaps you couldn't anticipate. Strict "identify all gaps, then investigate" prevents the most common discovery pattern: "I found X, which means I also need to understand Y." Investigation and gap identification are interleaved.
+
+### "Investigation requires dedicated source adapters"
+**False for v1.** Claude Code has WebSearch and WebFetch built in. Adding Brave is one more. The "adapter architecture" framing implies pluggable interfaces, registration, dispatch logic. In reality, "use WebSearch, optionally use Brave" is a prompt instruction, not an architecture.
+
+### "Analysis requires thinking models as a separate step"
+**Partially true.** Thinking models are valuable, but separating investigation from analysis implies "gather all facts first, then think." In practice, analysis happens *during* investigation. Making it separate risks a mechanical "now apply 3 frameworks" phase instead of integrated critical thinking throughout.
+
+### "Synthesis must produce a specific document format (DISCOVERY.md)"
+**True as convention, not fundamental.** The fundamental truth: findings must be *persisted* and *readable by the planner*. The format is a convention. The value is persistence + consumption, not the schema.
+
+### "The user must confirm gaps before investigation begins"
+**Partially true.** Gates prevent wasted work, but every gate is a blocking interaction. If the agent identifies 3 obvious gaps, the gate adds latency without value. Gates should exist for *consequential* decisions (spending money on API calls, changing the issue body), not for every step transition.
+
+### "This needs to be a structured workflow at all"
+**The deepest assumption.** What if the best pre-planning knowledge work is just a good prompt? "Check what you know. Identify gaps. Research specific questions. Think critically. Write DISCOVERY.md. Update the issue." The "workflow" is Claude's natural reasoning process, guided by a prompt.
+
+## Fundamental Truths (Irreducible)
+
+1. **An agent makes better plans when it knows more about the problem domain.** Discovery is only valuable when there are genuine unknowns.
+
+2. **The agent cannot know what it doesn't know without checking.** The prior knowledge check forces confrontation with the boundary between "I know this" and "I'm guessing."
+
+3. **External research produces better results with specific questions than broad topics.** Gap identification (turning unknowns into specific questions) is the highest-leverage activity in the entire workflow.
+
+4. **Findings must outlive the session.** Persisting to files means the planner (in a different session) can read them.
+
+5. **Decisions made during discovery must constrain planning.** Discovery outputs must be *authoritative* for planning. Locked/deferred/discretion is a mechanism for this truth.
+
+6. **The user is the judge of sufficiency.** No programmatic scoring replaces the user saying "that's enough" or "dig deeper on X."
+
+## Rebuilt Understanding — The Irreducible Core
+
+Six activities, not seven steps. Activities 3 and 4 are interleaved, not sequential:
+
+1. **Confront ignorance.** Force the agent to distinguish what it knows from what it's assuming. Check existing knowledge. Surface the boundary explicitly.
+
+2. **Ask specific questions.** Turn vague unknowns into concrete, searchable questions. The single most valuable activity.
+
+3. **Search and read.** Use whatever tools are available to answer the specific questions. No adapter architecture — just "search for answers."
+
+4. **Think critically.** Challenge assumptions, surface trade-offs, compare options. Integrated into research, not a separate phase. Thinking models are prompting techniques that improve quality, not a phase.
+
+5. **Write it down.** Persist findings + decisions to a file the planner will read. Clearly state what was decided and what was deferred.
+
+6. **Update the issue.** (Epic-level only.) Enrich the GitHub issue so it's accurate and actionable.
+
+## New Possibilities
+
+- **Discovery as a prompt, not a pipeline.** A well-written skill prompt that guides Claude's natural reasoning. No steps, no gates, no modes.
+
+- **Merge investigation and analysis.** "Research each gap, and as you research, apply critical thinking." Better output because analysis is contextual, not mechanical.
+
+- **Two gates only.** (1) "Here's what I know — enough, or research externally?" (prevents unnecessary API spend). (2) "Here are findings and decisions — write DISCOVERY.md and update issue?" (prevents unwanted persistence).
+
+- **7-step model as internal prompt structure, not user-visible workflow.** Ensures Claude covers all bases, but user sees: "Here's what I know. Here are the gaps. [gate] Here's what I found. [gate] Done."
+
+- **Project discovery is a conversation, not a workflow.** Epic discovery benefits from structure. Project discovery is exploratory — forcing it into a structured workflow may make it worse. Consider: project discovery = conversation; epic discovery = skill.

--- a/.planning/discovery-design/03-inversion.md
+++ b/.planning/discovery-design/03-inversion.md
@@ -1,0 +1,77 @@
+# Inversion Analysis — Discovery Workflow Design
+
+> **Date:** 2026-04-08
+> **Question:** What would guarantee this discovery workflow fails or goes unused?
+> **Context:** Post via-negativa (16 features cut) and first-principles (7 steps challenged, 6 irreducible truths identified). Surviving design is a Claude Code skill with conversational intake, prior knowledge check, gap identification, investigation, integrated critical thinking, DISCOVERY.md output, and issue enrichment.
+
+## Goal
+
+A discovery workflow that the user actually runs before epics with unknowns, that produces findings the planner actually uses, and that doesn't get abandoned like the previous pipeline.
+
+## Guaranteed Failure Modes
+
+### 1. Make it slower than just winging it
+If running `/epic discover 178` takes 20 minutes of interaction before any research happens (intake questions, gap confirmation gates, mode selection), the user will skip it and go straight to planning. The previous pipeline burned ~155k tokens before coding started.
+— **Avoid by:** minimal gates (two at most). The skill should produce useful output within 2 minutes of invocation. No mode selection, no configuration. Start working immediately.
+
+### 2. Produce output the planner ignores
+If DISCOVERY.md exists but the planner doesn't read it — or reads it and treats it as advisory rather than authoritative — discovery was wasted effort. Most insidious failure mode: user did the work but got no benefit.
+— **Avoid by:** the planner skill/prompt MUST explicitly read DISCOVERY.md and commit to locked decisions. This is a contract between skills, not a hope. Test it: run a plan after discovery and verify locked decisions appear unmodified.
+
+### 3. Ask the user questions they can't answer
+"What consistency model do you need for your read-heavy workload?" — if the user knew, they wouldn't need discovery. Asking unanswerable questions makes the tool feel useless.
+— **Avoid by:** intake asks about goals, constraints, and concerns — not technical specifics. "What are you trying to build? What worries you? What have you tried?" The tool answers the technical questions, not asks them.
+
+### 4. Research things the agent already knows well enough
+Claude's training data covers most mainstream technologies adequately. If Claude spends 10 minutes researching Redis basics via WebSearch, that's waste. Discovery should only go external for genuine unknowns or where current/accurate information matters (pricing, compatibility, breaking changes).
+— **Avoid by:** honest prior knowledge check. "Here's what I know about Redis caching — likely sufficient from training data. The gap: I don't know the current `redis-py` async API surface or compatibility with SQLAlchemy 2.0. Research that specific question?" Research the delta, not the whole topic.
+
+### 5. Make the output format more important than the content
+If the skill spends effort ensuring DISCOVERY.md has perfect YAML frontmatter and numbered decision formats — but findings are shallow — format won over substance. The previous pipeline had perfect JSON schemas and empty insights.
+— **Avoid by:** simple output format. A few markdown headers, prose content, a decisions list. If the agent spends more time formatting than thinking, the format is too complex.
+
+### 6. Silently produce inferior results from missing infrastructure
+If Brave API key isn't set and the skill silently falls back to WebSearch — producing shallower, less independent search results — the user gets worse findings without knowing why. They make decisions based on thin evidence. Silent degradation IS a workaround, and workarounds are banned.
+— **Avoid by:** infrastructure is required, not optional. If Brave Search is part of the workflow, the API key must be configured. If it's missing: STOP, report the error clearly ("Brave API key not configured — discovery requires it"), and tell the user how to fix it. No graceful degradation. No silent fallbacks. Fail fast, fail loud. Same principle applies to any future adapter added to the workflow.
+
+### 7. Try to be comprehensive instead of useful
+Researching every possible angle to produce an exhaustive document. The user doesn't need 3000 words on Cassandra. They need: "For our use case, here's what matters, here's the recommendation, here are the 2 risks."
+— **Avoid by:** the skill prompt explicitly says "focus on what changes the plan, not what's interesting." Decision-relevant findings only. If a finding doesn't affect a planning decision, cut it.
+
+### 8. Require the user to validate every intermediate step
+"Here are the gaps — confirm?" "Here are the search queries — confirm?" "Here are the raw results — confirm?" Each gate is friction. The previous pipeline had validation steps that blocked progress.
+— **Avoid by:** two gates maximum. (1) After prior knowledge: "enough, or research?" (2) After findings: "write and update issue?" Everything between those gates is autonomous.
+
+### 9. Build it as infrastructure instead of a skill
+The moment there's a Python module, an adapter interface, a registration system, a dispatch layer — you're rebuilding the pipeline that died. A Claude Code skill is a prompt file. The "architecture" is the prompt structure.
+— **Avoid by:** v1 is a `.md` skill file. No Python. No scripts. No adapter classes. If the prompt can't express the workflow, the workflow is too complex.
+
+### 10. Design for the general case before solving the specific one
+Extractability, portability, "any project can install this" — these dilute focus. Build for GTS first.
+— **Avoid by:** use GTS paths, conventions, issue format. Don't abstract. Hardcode what you know.
+
+### 11. Never actually use it
+Most likely failure mode. Design complete, implementation done, but the user never reaches for it because going straight to planning is path of least resistance.
+— **Avoid by:** make invocation trivial. Make first output appear fast. Make output tangibly better than planning without it. Value must be obvious on first use.
+
+## Anti-Goals (Never Do)
+
+- Never ask the user to configure the tool before using it (config is a prerequisite, not a step)
+- Never produce output longer than what the planner needs to read
+- Never silently degrade — fail fast if infrastructure is missing
+- Never add a step that exists for "completeness" rather than utility
+- Never require the user to read or approve raw research results
+- Never build Python infrastructure for what a prompt can express
+- Never research topics Claude already knows well enough from training data
+- Never let the output format dictate the workflow
+- Never implement workarounds or fallbacks — fix the real problem
+
+## Success By Avoidance
+
+By not adding ceremony, not gating every transition, not building infrastructure, not degrading silently, and not prioritising comprehensiveness over relevance — the tool becomes fast enough to actually use. The previous pipeline failed because it prioritised rigour over velocity. Discovery succeeds by being lightweight enough that skipping it feels like skipping a useful step, not dodging an obligation.
+
+## Remaining Risk
+
+- **Quality variance.** Brave + WebFetch may produce shallow results for niche technical topics. The user may need to manually provide URLs or context. The skill should handle user-provided context well.
+- **Planner integration.** The contract between discovery output and planner input is critical and untested. If the planner doesn't respect locked decisions, the whole system breaks. Test early.
+- **Scope creep in the skill prompt.** As edge cases appear, the temptation is to add more instructions, conditions, formatting rules. The skill prompt must stay lean or it'll bloat into the same over-engineering that killed the pipeline.

--- a/.planning/discovery-design/04-second-order.md
+++ b/.planning/discovery-design/04-second-order.md
@@ -1,0 +1,66 @@
+# Second-Order Effects Analysis — Discovery Workflow Design
+
+> **Date:** 2026-04-08
+> **Question:** What are the consequences of consequences when building this discovery workflow?
+> **Context:** Post via-negativa, first-principles, and inversion. User wants thorough discovery with simple implementation. No shortcuts on research quality.
+
+## Chain 1: Planner reads DISCOVERY.md with locked decisions
+
+**First-order:** Planner receives authoritative constraints. Locked decisions implemented without re-evaluation. Planning is faster — narrower decision space.
+
+**Second-order:** Planner becomes *dependent* on DISCOVERY.md. Epics without discovery have unconstrained planning — quality gap becomes visible between discovered and undiscovered epics.
+
+**Third-order:** User starts running discovery on *every* epic, even without obvious unknowns, because constrained plans are consistently better. Positive feedback loop — more discovery files = more prior knowledge = faster future discoveries.
+
+**Design implication:** Don't fight this tendency. Design the skill so it's fast enough for "light discovery" (mostly prior knowledge, minimal external research) as well as deep investigation. The prior knowledge gate ("this is sufficient") is the natural fast-path.
+
+## Chain 2: Investigation sources can't answer niche questions
+
+**First-order:** Brave returns generic results. WebFetch retrieves docs but they're API references without architectural guidance. Discovery has gaps — questions marked as "Unknowns."
+
+**Second-order:** User provides context directly: specific URLs, maintainer conversations, direct experience. Discovery becomes *collaborative* — part automated, part human knowledge injection. This is the right model.
+
+**Third-order:** Skill needs to handle user-provided context as first-class input. DISCOVERY.md attributes both automated and human sources. More thorough than either alone.
+
+**Design implication:** Skill must explicitly invite user input during investigation. "I couldn't find definitive guidance on X. Do you have a source, a contact, or direct experience?" Make the collaborative path first-class. Consider Perplexity Sonar as a required v1 adapter — its synthesis capability addresses the niche question gap.
+
+## Chain 3: Epic discovery produces knowledge useful beyond the epic
+
+**First-order:** General findings trapped in `.planning/epics/E178/DISCOVERY.md`.
+
+**Second-order:** Future discoveries check prior epic DISCOVERY.md files as prior knowledge. Works but noisy — reading through epic-specific context to extract general knowledge.
+
+**Third-order:** After 10+ epics, substantial knowledge is fragmented across epic-specific files. Prior knowledge step gets slower. Per-epic organisation becomes a retrieval problem.
+
+**Design implication:** Cross-scope promotion (cut in via negativa) needed sooner than expected. Not automated — manual step in enrichment: "These findings about pgmq patterns are general. I'll also write them to `.planning/discovery/messaging-patterns.md`." Skill prompts for this; user confirms.
+
+**Revised position:** Reinstate cross-scope promotion as manual, user-confirmed step.
+
+## Chain 4: Discovery as pre-planning step
+
+**First-order:** Workflow gains a phase: issue → discover → plan → implement. Each epic takes longer to *start* but planning is faster with fewer mid-implementation pivots.
+
+**Second-order:** Total time per epic may *decrease*. Mid-implementation discoveries ("this library doesn't support async") caught earlier. Cost front-loaded; savings distributed across planning and implementation.
+
+**Third-order:** User's relationship with uncertainty changes. "What don't we know?" becomes the default question. Issues written with explicit unknowns. Epics scoped smaller when unknowns are large.
+
+**Delayed consequence:** Risk of *discovery paralysis* — reluctance to start without discovery. Antidote: prior knowledge gate makes fast path genuinely fast (2 minutes when sufficient).
+
+## Chain 5: Quality after 5-10 discovery files
+
+**First-order:** Plans are well-constrained and informed.
+
+**Second-order:** Prior knowledge check now has substantial material. New discoveries start from a richer base.
+
+**Third-order:** Discovery sessions get *shorter over time*. First discovery: 30 minutes. Fifth discovery: 10 minutes. **Compounding returns** — strongest argument for the workflow. Not just per-epic value, but cumulative project-level value.
+
+**Delayed consequence:** Accumulated discovery files become useful project documentation — battle-tested findings, not aspirational docs. Risk of two sources of truth (wiki vs discovery). Need clear boundary: `.planning/discovery/` for investigated findings with decisions; wiki for reference architecture and operational docs.
+
+## Key Insights
+
+1. **Discovery has compounding returns.** Each session makes future sessions cheaper. First 2-3 are most expensive and least impressive — must persist through bootstrap cost.
+2. **Cross-scope promotion should be in v1** — manual, user-confirmed, but present from start.
+3. **Planner integration is the critical contract** — untested = not working.
+4. **User input during investigation is essential** — pure automated research won't cover niche questions.
+5. **Fast path must be genuinely fast** — prior knowledge sufficient = done in 2 minutes.
+6. **Wiki/discovery boundary needs a convention** — establish before first discovery session.

--- a/.planning/discovery-design/05-open-questions-resolved.md
+++ b/.planning/discovery-design/05-open-questions-resolved.md
@@ -1,0 +1,35 @@
+# Open Questions — Resolved
+
+> **Date:** 2026-04-08
+> **Source:** Discovery-Workflow-Design.md "Open Questions" section
+> **Resolved by:** Via negativa, first principles, inversion, and second-order analyses
+
+## Q1: Assumptions mode trigger
+
+> Should the tool auto-detect when assumptions mode is appropriate, or always require explicit opt-in?
+
+**Resolution: Question eliminated.** Assumptions mode was cut entirely (via negativa). A good intake step naturally proposes what it knows and asks the user to correct — that IS assumptions mode. No separate mode, no trigger, no opt-in. The skill always works this way: surface existing knowledge, let the user correct.
+
+## Q2: Epic discovery mandatory vs optional
+
+> Should the epic pipeline prompt "Run discovery first?" when it detects unknowns, or remain purely user-triggered?
+
+**Resolution: User-triggered, but practically default.** Second-order analysis (Chain 1) shows discovery tends toward becoming the default over time because constrained plans are consistently better. The prior knowledge fast-path (2 minutes when sufficient) makes it cheap to run even for straightforward epics. No need for the pipeline to auto-detect unknowns — the user runs discovery, and if prior knowledge is sufficient, it terminates quickly.
+
+## Q3: Adapter failure strategy
+
+> Should discovery be strict (all must complete) or resilient (synthesise from whatever succeeded, flag gaps)?
+
+**Resolution: Strict. All required adapters must complete.** User directive: "API keys should always be required. We should not continue if anything in the infrastructure is not available. We do not defer. No technical debt." Silent degradation is a workaround, and workarounds are banned (AGENTS.md). If an adapter fails: STOP, report the error, tell the user how to fix it. No graceful degradation. No silent fallbacks.
+
+## Q4: Session management
+
+> For deep discovery that exceeds one context window, how should handoff work?
+
+**Resolution: Not a v1 design concern.** First-principles analysis concluded project discovery is a conversation (naturally fits one session with user steering). Epic discovery is narrow scope (1-3 focused questions) — should fit in one session. If a session does exceed context, use the existing `/whats-next` handoff mechanism. No custom session management needed. Solve if it becomes a real problem.
+
+## Q5: Adapter quality evaluation framework
+
+> How do we systematically compare adapter output quality over time?
+
+**Resolution: Observation, not framework.** Via negativa cut this as premature infrastructure. You'll know what works by using it. After 5-10 discovery sessions, patterns will be obvious — "Brave consistently finds better technical content than WebSearch" or "Perplexity Sonar answers architectural questions well but misses implementation details." No structured scoring, no A/B infrastructure. Just use the tools and pay attention.


### PR DESCRIPTION
## Summary
- Stress-tested the discovery workflow design using 4 analytical frameworks (via negativa, first principles, inversion, second-order effects)
- Cut 16 features from the original design, resolved all 5 open questions
- Revised wiki doc: 8 adapters → 2 required, 7 sequential steps → 6 interleaved activities, mandatory infrastructure (no graceful degradation)
- Analysis files preserved in `.planning/discovery-design/` for decision traceability

## Test plan
- [x] Regression tests pass (28/28)
- [x] No code changes — design docs only
- [x] Wiki doc updated and pushed separately

Closes #178