### PR TITLE
pgmq/job archive retention so the DB never rebloats [DB-pgmq-retention]

### DIFF
--- a/apps/t3k_sync/src/t3k_sync/main.py
+++ b/apps/t3k_sync/src/t3k_sync/main.py
@@ -24,8 +24,6 @@ from t3k_sync.tasks import (
     dispatch_pending_jobs,
     monitor_stale_jobs,
     process_pending_retries,
-    purge_old_jobs,
-    purge_pgmq_archives,
     refresh_t3k_token,
 )
 
@@ -74,8 +72,6 @@ async def lifespan(_: FastAPI):
             ("process_pending_retries", process_pending_retries, 120.0),
             ("dispatch_pending_jobs", dispatch_pending_jobs, 120.0),
             ("backup_all_databases", backup_all_databases, 43200.0),
-            ("purge_pgmq_archives", purge_pgmq_archives, 86400.0),
-            ("purge_old_jobs", purge_old_jobs, 86400.0),
         ]
 
         shutdown = asyncio.Event()

--- a/apps/t3k_sync/src/t3k_sync/main.py
+++ b/apps/t3k_sync/src/t3k_sync/main.py
@@ -24,6 +24,8 @@ from t3k_sync.tasks import (
     dispatch_pending_jobs,
     monitor_stale_jobs,
     process_pending_retries,
+    purge_old_jobs,
+    purge_pgmq_archives,
     refresh_t3k_token,
 )
 
@@ -72,6 +74,8 @@ async def lifespan(_: FastAPI):
             ("process_pending_retries", process_pending_retries, 120.0),
             ("dispatch_pending_jobs", dispatch_pending_jobs, 120.0),
             ("backup_all_databases", backup_all_databases, 43200.0),
+            ("purge_pgmq_archives", purge_pgmq_archives, 86400.0),
+            ("purge_old_jobs", purge_old_jobs, 86400.0),
         ]
 
         shutdown = asyncio.Event()

--- a/apps/t3k_sync/src/t3k_sync/tasks.py
+++ b/apps/t3k_sync/src/t3k_sync/tasks.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -34,6 +35,8 @@ _FALLBACK_REFRESH_SECONDS = 1800
 _BACKUPS_DIR = Path("/app/backups")
 _DISPATCH_MAX_FAILURES = 3
 _DISPATCH_COOLDOWN = timedelta(minutes=30)
+# pgmq archive table names are a_ + alphanumeric/underscore (from system catalog, not user input).
+_PGMQ_ARCHIVE_TABLE_RE = re.compile(r"^a_[a-z][a-z0-9_]*$")
 
 # Test hook: set by tests to inject the test session into DB tasks.
 # Allows task functions to share the test's SAVEPOINT-isolated session.
@@ -379,6 +382,77 @@ async def dispatch_pending_jobs() -> None:
 
     if dispatched > 0:
         logger.info("Dispatched %d stuck pending jobs", dispatched)
+
+
+# ---------------------------------------------------------------------------
+# Retention / purge
+# ---------------------------------------------------------------------------
+
+
+async def purge_pgmq_archives() -> None:
+    """Delete pgmq archive rows older than PGMQ_ARCHIVE_RETENTION_DAYS (default: 30)."""
+    retention_days = int(os.getenv("PGMQ_ARCHIVE_RETENTION_DAYS", "30"))
+    cutoff = datetime.now(UTC) - timedelta(days=retention_days)
+
+    discover_stmt = text(
+        "SELECT table_name FROM information_schema.tables"
+        " WHERE table_schema = 'pgmq' AND table_name LIKE 'a_%' AND table_type = 'BASE TABLE'"
+    )
+
+    async def _purge(session: AsyncSession) -> int:
+        result = await session.execute(discover_stmt)
+        table_names = [row[0] for row in result.fetchall()]
+        total = 0
+        for table_name in table_names:
+            if not _PGMQ_ARCHIVE_TABLE_RE.match(table_name):
+                logger.warning("Skipping unexpected pgmq archive table: %r", table_name)
+                continue
+            del_result = await session.execute(
+                text(f"DELETE FROM pgmq.{table_name} WHERE archived_at < :cutoff"),
+                {"cutoff": cutoff},
+            )
+            total += del_result.rowcount
+        return total
+
+    if _test_session is not None:
+        deleted = await _purge(_test_session)
+    else:
+        async with get_core_session() as session:
+            deleted = await _purge(session)
+            await session.commit()
+
+    if deleted:
+        logger.info("Purged %d rows from pgmq archives (cutoff: %s)", deleted, cutoff.date())
+
+
+async def purge_old_jobs() -> None:
+    """Delete terminal core_jobs older than JOB_RETENTION_DAYS (default: 90)."""
+    retention_days = int(os.getenv("JOB_RETENTION_DAYS", "90"))
+    cutoff = datetime.now(UTC) - timedelta(days=retention_days)
+    terminal = [
+        JobStatus.COMPLETED.value,
+        JobStatus.FAILED.value,
+        JobStatus.DEAD_LETTERED.value,
+    ]
+    stmt = text(
+        "DELETE FROM core_jobs"
+        " WHERE status = ANY(:statuses)"
+        " AND completed_at IS NOT NULL"
+        " AND completed_at < :cutoff"
+    )
+    params: dict[str, object] = {"statuses": terminal, "cutoff": cutoff}
+
+    if _test_session is not None:
+        result = await _test_session.execute(stmt, params)
+        deleted = result.rowcount
+    else:
+        async with get_core_session() as session:
+            result = await session.execute(stmt, params)
+            await session.commit()
+            deleted = result.rowcount
+
+    if deleted:
+        logger.info("Purged %d terminal jobs (cutoff: %s)", deleted, cutoff.date())
 
 
 # ---------------------------------------------------------------------------

--- a/apps/t3k_sync/src/t3k_sync/tasks.py
+++ b/apps/t3k_sync/src/t3k_sync/tasks.py
@@ -517,7 +517,12 @@ def _cleanup_old_backups(retention_days: int) -> None:
 
 
 async def backup_all_databases() -> None:
-    """Discover and back up all application databases."""
+    """Discover and back up all application databases.
+
+    On full success, runs retention purges (pgmq archives and terminal jobs)
+    so they are always sequenced after a confirmed backup, never before or
+    concurrently with it.
+    """
     host, user, password = _parse_db_connection()
     databases = await _discover_databases(host, user, password)
 
@@ -529,6 +534,7 @@ async def backup_all_databases() -> None:
     timestamp = datetime.now().strftime("%Y%m%d_%H%M")
     env = {**os.environ, "PGPASSWORD": password}
 
+    failed: list[str] = []
     for db_name in databases:
         backup_file = _BACKUPS_DIR / f"{db_name}.{timestamp}.dump"
         try:
@@ -552,17 +558,20 @@ async def backup_all_databases() -> None:
                     await proc.wait()
                     backup_file.unlink(missing_ok=True)
                     logger.error("pg_dump timed out for %s", db_name)
+                    failed.append(db_name)
                     continue
 
             if proc.returncode != 0:
                 backup_file.unlink(missing_ok=True)
                 logger.error("pg_dump failed for %s: %s", db_name, stderr_data.decode().strip())
+                failed.append(db_name)
                 continue
 
             size = backup_file.stat().st_size
             if size < 100:
                 backup_file.unlink(missing_ok=True)
                 logger.error("Backup too small for %s — database may be empty", db_name)
+                failed.append(db_name)
                 continue
 
             logger.info("Backed up %s: %s (%.1f MB)", db_name, backup_file.name, size / 1024 / 1024)
@@ -570,6 +579,18 @@ async def backup_all_databases() -> None:
         except Exception:
             backup_file.unlink(missing_ok=True)
             logger.exception("Failed to back up %s", db_name)
+            failed.append(db_name)
 
     retention_days = int(os.getenv("BACKUP_RETENTION_DAYS", "7"))
     _cleanup_old_backups(retention_days)
+
+    if failed:
+        logger.warning(
+            "Skipping retention purge — %d database backup(s) failed: %s",
+            len(failed),
+            ", ".join(failed),
+        )
+        return
+
+    await purge_pgmq_archives()
+    await purge_old_jobs()

--- a/apps/t3k_sync/src/t3k_sync/tasks.py
+++ b/apps/t3k_sync/src/t3k_sync/tasks.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import httpx
-from sqlalchemy import text
+from sqlalchemy import column, delete, table, text
 
 from gts.domain.auth_gate import check_auth_status
 from gts.domain.value_objects.job_status import JobStatus
@@ -407,9 +407,11 @@ async def purge_pgmq_archives() -> None:
             if not _PGMQ_ARCHIVE_TABLE_RE.match(table_name):
                 logger.warning("Skipping unexpected pgmq archive table: %r", table_name)
                 continue
+            # Use SQLAlchemy's structured expression API so the table identifier
+            # is quoted by the dialect rather than interpolated into a raw SQL string.
+            archive_tbl = table(table_name, column("archived_at"), schema="pgmq")
             del_result = await session.execute(
-                text(f"DELETE FROM pgmq.{table_name} WHERE archived_at < :cutoff"),
-                {"cutoff": cutoff},
+                delete(archive_tbl).where(archive_tbl.c.archived_at < cutoff)
             )
             total += del_result.rowcount
         return total

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,6 +129,11 @@ services:
       OAUTH_ENCRYPTION_KEY: ${OAUTH_ENCRYPTION_KEY}
       T3K_API_KEY: ${T3K_API_KEY:-}
       GTS_STORAGE_ROOT: /app/storage
+      # Retention windows for the periodic backup/purge task (t3k_sync.tasks).
+      # Defaults match the code; override per-deployment via the host env.
+      BACKUP_RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-7}
+      PGMQ_ARCHIVE_RETENTION_DAYS: ${PGMQ_ARCHIVE_RETENTION_DAYS:-30}
+      JOB_RETENTION_DAYS: ${JOB_RETENTION_DAYS:-90}
     volumes:
       - ./model:/app/model
       - ./infra:/app/infra

--- a/tests/unit/scheduler/test_scheduled_tasks.py
+++ b/tests/unit/scheduler/test_scheduled_tasks.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import os
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 from gts.domain.entities.job import Job
 from gts.domain.value_objects.job_status import JobStatus, JobType
@@ -254,3 +255,213 @@ class TestProcessPendingRetries:
 
         await session.refresh(job_model)
         assert job_model.status == JobStatus.COMPLETED.value
+
+
+class TestPurgePgmqArchives:
+    """Test purge_pgmq_archives scheduled task."""
+
+    async def test_deletes_old_archive_rows(self, session: AsyncSession) -> None:
+        """Archive rows older than the retention window are deleted."""
+        from t3k_sync.tasks import purge_pgmq_archives
+
+        # Create a dedicated test queue (transactional DDL — rolled back after test).
+        await session.execute(text("SELECT pgmq.create('purge_test_q')"))
+        await session.execute(text("SELECT pgmq.send('purge_test_q', '{}'::jsonb)"))
+        msg_result = await session.execute(
+            text("SELECT msg_id FROM pgmq.read('purge_test_q', 30, 1)")
+        )
+        msg_id = msg_result.scalar_one()
+        await session.execute(
+            text("SELECT pgmq.archive('purge_test_q', CAST(:msg_id AS bigint))"),
+            {"msg_id": msg_id},
+        )
+        # Backdate to 31 days ago (beyond the 30-day default window).
+        await session.execute(
+            text("UPDATE pgmq.a_purge_test_q SET archived_at = :old_time"),
+            {"old_time": datetime.now(UTC) - timedelta(days=31)},
+        )
+
+        prev_env = os.environ.pop("PGMQ_ARCHIVE_RETENTION_DAYS", None)
+        try:
+            os.environ["PGMQ_ARCHIVE_RETENTION_DAYS"] = "30"
+            await purge_pgmq_archives()
+        finally:
+            if prev_env is None:
+                os.environ.pop("PGMQ_ARCHIVE_RETENTION_DAYS", None)
+            else:
+                os.environ["PGMQ_ARCHIVE_RETENTION_DAYS"] = prev_env
+
+        count = await session.execute(text("SELECT COUNT(*) FROM pgmq.a_purge_test_q"))
+        assert count.scalar_one() == 0
+
+    async def test_keeps_recent_archive_rows(self, session: AsyncSession) -> None:
+        """Archive rows within the retention window are not deleted."""
+        from t3k_sync.tasks import purge_pgmq_archives
+
+        await session.execute(text("SELECT pgmq.create('purge_recent_q')"))
+        await session.execute(text("SELECT pgmq.send('purge_recent_q', '{}'::jsonb)"))
+        msg_result = await session.execute(
+            text("SELECT msg_id FROM pgmq.read('purge_recent_q', 30, 1)")
+        )
+        msg_id = msg_result.scalar_one()
+        await session.execute(
+            text("SELECT pgmq.archive('purge_recent_q', CAST(:msg_id AS bigint))"),
+            {"msg_id": msg_id},
+        )
+        # archived_at defaults to now() — well within 30-day window.
+
+        prev_env = os.environ.pop("PGMQ_ARCHIVE_RETENTION_DAYS", None)
+        try:
+            os.environ["PGMQ_ARCHIVE_RETENTION_DAYS"] = "30"
+            await purge_pgmq_archives()
+        finally:
+            if prev_env is None:
+                os.environ.pop("PGMQ_ARCHIVE_RETENTION_DAYS", None)
+            else:
+                os.environ["PGMQ_ARCHIVE_RETENTION_DAYS"] = prev_env
+
+        count = await session.execute(text("SELECT COUNT(*) FROM pgmq.a_purge_recent_q"))
+        assert count.scalar_one() == 1
+
+    async def test_no_error_when_no_archive_tables(self, session: AsyncSession) -> None:
+        """Function completes without error when no pgmq archive tables exist."""
+        from t3k_sync.tasks import purge_pgmq_archives
+
+        # Rely on the fact that whatever tables exist will have no rows old enough
+        # with a very short retention — just verify it doesn't raise.
+        prev_env = os.environ.pop("PGMQ_ARCHIVE_RETENTION_DAYS", None)
+        try:
+            os.environ["PGMQ_ARCHIVE_RETENTION_DAYS"] = "36500"  # 100 years — deletes nothing
+            await purge_pgmq_archives()
+        finally:
+            if prev_env is None:
+                os.environ.pop("PGMQ_ARCHIVE_RETENTION_DAYS", None)
+            else:
+                os.environ["PGMQ_ARCHIVE_RETENTION_DAYS"] = prev_env
+
+
+class TestPurgeOldJobs:
+    """Test purge_old_jobs scheduled task."""
+
+    async def test_deletes_old_terminal_jobs(self, session: AsyncSession) -> None:
+        """Completed/failed/dead-lettered jobs older than the retention window are deleted."""
+        from t3k_sync.tasks import purge_old_jobs
+        from webapp.adapters.persistence.models.job import Job as JobModel
+
+        old_time = datetime.now(UTC) - timedelta(days=91)
+        job_ids = []
+        for status in (JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.DEAD_LETTERED):
+            entity = Job(
+                id=uuid4(),
+                user_id=None,
+                job_type=JobType.AUDIO_PROCESSING,
+                status=status,
+                completed_at=old_time,
+            )
+            job_ids.append(entity.id)
+            session.add(JobModel.from_entity(entity))
+        await session.commit()
+
+        prev_env = os.environ.pop("JOB_RETENTION_DAYS", None)
+        try:
+            os.environ["JOB_RETENTION_DAYS"] = "90"
+            await purge_old_jobs()
+        finally:
+            if prev_env is None:
+                os.environ.pop("JOB_RETENTION_DAYS", None)
+            else:
+                os.environ["JOB_RETENTION_DAYS"] = prev_env
+
+        result = await session.execute(select(JobModel).where(JobModel.id.in_(job_ids)))
+        assert result.scalars().all() == []
+
+    async def test_keeps_recent_terminal_jobs(self, session: AsyncSession) -> None:
+        """Terminal jobs within the retention window are not deleted."""
+        from t3k_sync.tasks import purge_old_jobs
+        from webapp.adapters.persistence.models.job import Job as JobModel
+
+        recent_time = datetime.now(UTC) - timedelta(days=10)
+        entity = Job(
+            id=uuid4(),
+            user_id=None,
+            job_type=JobType.AUDIO_PROCESSING,
+            status=JobStatus.COMPLETED,
+            completed_at=recent_time,
+        )
+        model = JobModel.from_entity(entity)
+        session.add(model)
+        await session.commit()
+
+        prev_env = os.environ.pop("JOB_RETENTION_DAYS", None)
+        try:
+            os.environ["JOB_RETENTION_DAYS"] = "90"
+            await purge_old_jobs()
+        finally:
+            if prev_env is None:
+                os.environ.pop("JOB_RETENTION_DAYS", None)
+            else:
+                os.environ["JOB_RETENTION_DAYS"] = prev_env
+
+        await session.refresh(model)
+        assert model.status == JobStatus.COMPLETED.value
+
+    async def test_does_not_delete_active_jobs(self, session: AsyncSession) -> None:
+        """PENDING and RUNNING jobs are never deleted regardless of age."""
+        from t3k_sync.tasks import purge_old_jobs
+        from webapp.adapters.persistence.models.job import Job as JobModel
+
+        old_time = datetime.now(UTC) - timedelta(days=91)
+        job_ids = []
+        for status in (JobStatus.PENDING, JobStatus.RUNNING):
+            entity = Job(
+                id=uuid4(),
+                user_id=None,
+                job_type=JobType.AUDIO_PROCESSING,
+                status=status,
+                completed_at=old_time,
+            )
+            job_ids.append(entity.id)
+            session.add(JobModel.from_entity(entity))
+        await session.commit()
+
+        prev_env = os.environ.pop("JOB_RETENTION_DAYS", None)
+        try:
+            os.environ["JOB_RETENTION_DAYS"] = "90"
+            await purge_old_jobs()
+        finally:
+            if prev_env is None:
+                os.environ.pop("JOB_RETENTION_DAYS", None)
+            else:
+                os.environ["JOB_RETENTION_DAYS"] = prev_env
+
+        result = await session.execute(select(JobModel).where(JobModel.id.in_(job_ids)))
+        assert len(result.scalars().all()) == 2
+
+    async def test_does_not_delete_jobs_without_completed_at(self, session: AsyncSession) -> None:
+        """Terminal jobs with NULL completed_at are not deleted."""
+        from t3k_sync.tasks import purge_old_jobs
+        from webapp.adapters.persistence.models.job import Job as JobModel
+
+        entity = Job(
+            id=uuid4(),
+            user_id=None,
+            job_type=JobType.AUDIO_PROCESSING,
+            status=JobStatus.COMPLETED,
+            completed_at=None,
+        )
+        model = JobModel.from_entity(entity)
+        session.add(model)
+        await session.commit()
+
+        prev_env = os.environ.pop("JOB_RETENTION_DAYS", None)
+        try:
+            os.environ["JOB_RETENTION_DAYS"] = "0"
+            await purge_old_jobs()
+        finally:
+            if prev_env is None:
+                os.environ.pop("JOB_RETENTION_DAYS", None)
+            else:
+                os.environ["JOB_RETENTION_DAYS"] = prev_env
+
+        await session.refresh(model)
+        assert model.status == JobStatus.COMPLETED.value


### PR DESCRIPTION
Periodic retention purge wired into the t3k-sync scheduler.

- `backup_all_databases` (runs every 12h in t3k_sync.main) purges pgmq archives older than `PGMQ_ARCHIVE_RETENTION_DAYS` (30) and terminal core_jobs older than `JOB_RETENTION_DAYS` (90), only after a successful backup; backup files pruned to `BACKUP_RETENTION_DAYS` (7).
- pgmq purge uses the SQLAlchemy expression API (no f-string SQL).
- The three retention windows are now exposed in the t3k-sync compose env so deployments can tune them; defaults match the code.

Closes the unbounded pgmq.a_* archive growth (hit 2.36M rows / 3.7G before the one-off purge).