### PR TITLE
Enforce query-level resource ownership in repositories [SEC-query-ownership] (#151)

### DIFF
--- a/apps/webapp/src/webapp/adapters/persistence/repositories/di_track_repository.py
+++ b/apps/webapp/src/webapp/adapters/persistence/repositories/di_track_repository.py
@@ -30,16 +30,17 @@ class SQLAlchemyDITrackRepository:
         """
         self.session = session
 
-    async def get_by_id(self, track_id: UUID) -> DITrackEntity | None:
-        """Get a DI track by its ID.
+    async def get_by_id(self, track_id: UUID, user_id: UUID) -> DITrackEntity | None:
+        """Get a DI track by ID, scoped to the owning user.
 
         Args:
             track_id: The track's UUID
+            user_id: The requesting user's UUID — included in the WHERE clause
 
         Returns:
-            The DITrack entity if found, None otherwise
+            The DITrack entity if found and owned, None otherwise
         """
-        stmt = select(DITrack).where(DITrack.id == track_id)
+        stmt = select(DITrack).where(DITrack.id == track_id, DITrack.user_id == user_id)
         result = await self.session.execute(stmt)
         track = result.scalar_one_or_none()
 

--- a/apps/webapp/src/webapp/adapters/persistence/repositories/job_repository.py
+++ b/apps/webapp/src/webapp/adapters/persistence/repositories/job_repository.py
@@ -31,16 +31,17 @@ class SQLAlchemyJobRepository:
         """
         self.session = session
 
-    async def get_by_id(self, job_id: UUID) -> JobEntity | None:
-        """Get a job by its ID.
+    async def get_by_id(self, job_id: UUID, user_id: UUID) -> JobEntity | None:
+        """Get a job by ID, scoped to the owning user.
 
         Args:
             job_id: The job's UUID
+            user_id: The requesting user's UUID — included in the WHERE clause
 
         Returns:
-            The Job entity if found, None otherwise
+            The Job entity if found and owned, None otherwise
         """
-        stmt = select(Job).where(Job.id == job_id)
+        stmt = select(Job).where(Job.id == job_id, Job.user_id == user_id)
         result = await self.session.execute(stmt)
         job = result.scalar_one_or_none()
 

--- a/apps/webapp/src/webapp/adapters/persistence/repositories/shootout_comment_repository.py
+++ b/apps/webapp/src/webapp/adapters/persistence/repositories/shootout_comment_repository.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
+from webapp.adapters.persistence.models.shootout import Shootout
 from webapp.adapters.persistence.models.shootout_comment import ShootoutComment
 
 
@@ -56,13 +57,20 @@ class ShootoutCommentRepository:
     async def list_by_shootout(
         self,
         shootout_id: UUID,
+        user_id: UUID,
         limit: int = 50,
         offset: int = 0,
     ) -> list[ShootoutComment]:
-        """List comments for a shootout, newest first.
+        """List comments for a shootout owned by ``user_id``, newest first.
+
+        Ownership is enforced in SQL by joining to Shootout and filtering on
+        Shootout.user_id, so comments never cross the owner boundary regardless
+        of how callers are wired.
 
         Args:
             shootout_id: ID of the shootout
+            user_id: The requesting user's UUID; only the shootout owner's
+                comments are returned
             limit: Maximum number of comments to return
             offset: Number of comments to skip
 
@@ -71,7 +79,9 @@ class ShootoutCommentRepository:
         """
         stmt = (
             select(ShootoutComment)
+            .join(Shootout, ShootoutComment.shootout_id == Shootout.id)
             .where(ShootoutComment.shootout_id == shootout_id)
+            .where(Shootout.user_id == user_id)
             .options(joinedload(ShootoutComment.user))
             .order_by(ShootoutComment.created_at.desc())
             .limit(limit)

--- a/apps/webapp/src/webapp/adapters/persistence/repositories/shootout_comment_repository.py
+++ b/apps/webapp/src/webapp/adapters/persistence/repositories/shootout_comment_repository.py
@@ -81,16 +81,19 @@ class ShootoutCommentRepository:
         result = await self.session.execute(stmt)
         return list(result.unique().scalars().all())
 
-    async def get_by_id(self, comment_id: UUID) -> ShootoutComment | None:
-        """Get a comment by ID.
+    async def get_by_id(self, comment_id: UUID, user_id: UUID) -> ShootoutComment | None:
+        """Get a comment by ID, scoped to the owning user.
 
         Args:
             comment_id: ID of the comment
+            user_id: The requesting user's UUID — included in the WHERE clause
 
         Returns:
-            Comment if found, None otherwise
+            Comment if found and owned, None otherwise
         """
-        stmt = select(ShootoutComment).where(ShootoutComment.id == comment_id)
+        stmt = select(ShootoutComment).where(
+            ShootoutComment.id == comment_id, ShootoutComment.user_id == user_id
+        )
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none()
 

--- a/apps/webapp/src/webapp/adapters/persistence/repositories/shootout_repository.py
+++ b/apps/webapp/src/webapp/adapters/persistence/repositories/shootout_repository.py
@@ -36,18 +36,19 @@ class SQLAlchemyShootoutRepository:
         """
         self.session = session
 
-    async def get_by_id(self, shootout_id: UUID) -> ShootoutEntity | None:
-        """Get a shootout by its ID.
+    async def get_by_id(self, shootout_id: UUID, user_id: UUID) -> ShootoutEntity | None:
+        """Get a shootout by ID, scoped to the owning user.
 
         Args:
             shootout_id: The shootout's UUID
+            user_id: The requesting user's UUID — included in the WHERE clause
 
         Returns:
-            The Shootout entity with all chains loaded, or None
+            The Shootout entity with all chains loaded, or None if not found or not owned
         """
         stmt = (
             select(Shootout)
-            .where(Shootout.id == shootout_id)
+            .where(Shootout.id == shootout_id, Shootout.user_id == user_id)
             .options(
                 joinedload(Shootout.di_track),
                 joinedload(Shootout.chains),

--- a/apps/webapp/src/webapp/adapters/persistence/repositories/signal_chain_group_repository.py
+++ b/apps/webapp/src/webapp/adapters/persistence/repositories/signal_chain_group_repository.py
@@ -32,16 +32,19 @@ class SQLAlchemySignalChainGroupRepository:
         """
         self.session = session
 
-    async def get_by_id(self, group_id: UUID) -> SignalChainGroupEntity | None:
-        """Get a group by its ID.
+    async def get_by_id(self, group_id: UUID, user_id: UUID) -> SignalChainGroupEntity | None:
+        """Get a group by ID, scoped to the owning user.
 
         Args:
             group_id: The group's UUID
+            user_id: The requesting user's UUID — included in the WHERE clause
 
         Returns:
-            The SignalChainGroup entity if found, None otherwise
+            The SignalChainGroup entity if found and owned, None otherwise
         """
-        stmt = select(SignalChainGroup).where(SignalChainGroup.id == group_id)
+        stmt = select(SignalChainGroup).where(
+            SignalChainGroup.id == group_id, SignalChainGroup.user_id == user_id
+        )
         result = await self.session.execute(stmt)
         group = result.scalar_one_or_none()
 

--- a/apps/webapp/src/webapp/adapters/persistence/repositories/signal_chain_repository.py
+++ b/apps/webapp/src/webapp/adapters/persistence/repositories/signal_chain_repository.py
@@ -37,18 +37,19 @@ class SQLAlchemySignalChainRepository:
         """
         self.session = session
 
-    async def get_by_id(self, chain_id: UUID) -> SignalChainEntity | None:
-        """Get a signal chain by its ID.
+    async def get_by_id(self, chain_id: UUID, user_id: UUID) -> SignalChainEntity | None:
+        """Get a signal chain by ID, scoped to the owning user.
 
         Args:
             chain_id: The chain's UUID
+            user_id: The requesting user's UUID — included in the WHERE clause
 
         Returns:
-            The SignalChain with all blocks loaded, or None
+            The SignalChain with all blocks loaded, or None if not found or not owned
         """
         stmt = (
             select(SignalChain)
-            .where(SignalChain.id == chain_id)
+            .where(SignalChain.id == chain_id, SignalChain.user_id == user_id)
             .options(joinedload(SignalChain.blocks))
         )
         result = await self.session.execute(stmt)

--- a/apps/webapp/src/webapp/api/pages/chains.py
+++ b/apps/webapp/src/webapp/api/pages/chains.py
@@ -114,9 +114,9 @@ async def chain_detail_page(
 ) -> HTMLResponse:
     """Render signal chain detail page."""
     repo = SQLAlchemySignalChainRepository(db)
-    chain = await repo.get_by_id(UUID(chain_id))
+    chain = await repo.get_by_id(UUID(chain_id), current_user.id)
 
-    if not chain or chain.user_id != current_user.id:
+    if chain is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Chain not found",
@@ -200,8 +200,8 @@ async def chain_delete_fragment(
     """Delete a signal chain via HTMX."""
     repo = SQLAlchemySignalChainRepository(db)
 
-    chain = await repo.get_by_id(UUID(chain_id))
-    if not chain or chain.user_id != current_user.id:
+    chain = await repo.get_by_id(UUID(chain_id), current_user.id)
+    if chain is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Chain not found",
@@ -228,8 +228,8 @@ async def chain_duplicate_fragment(
 
     repo = SQLAlchemySignalChainRepository(db)
 
-    chain = await repo.get_by_id(UUID(chain_id))
-    if not chain or chain.user_id != current_user.id:
+    chain = await repo.get_by_id(UUID(chain_id), current_user.id)
+    if chain is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Chain not found",

--- a/apps/webapp/src/webapp/api/pages/di_tracks.py
+++ b/apps/webapp/src/webapp/api/pages/di_tracks.py
@@ -132,10 +132,12 @@ async def library_track_toggle_public(
     current_user: Annotated[User, Depends(get_current_user_required)],
 ) -> HTMLResponse:
     """Toggle a DI track's public visibility. Returns updated track_item."""
-    result = await db.execute(select(DITrack).where(DITrack.id == UUID(track_id)))
+    result = await db.execute(
+        select(DITrack).where(DITrack.id == UUID(track_id), DITrack.user_id == current_user.id)
+    )
     track = result.scalar_one_or_none()
 
-    if not track or track.user_id != current_user.id:
+    if track is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Track not found",

--- a/apps/webapp/src/webapp/api/pages/gear.py
+++ b/apps/webapp/src/webapp/api/pages/gear.py
@@ -59,17 +59,18 @@ async def gear_browse_page(
     tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
 
     offset = (page - 1) * page_size
-    total = await service.count(query=search, gear_type=gt_filter, tags=tag_list)
+    total = await service.count(query=search, gear_type=gt_filter, tags=tag_list, is_public=True)
     gear_items = await service.search(
         query=search,
         gear_type=gt_filter,
         tags=tag_list,
+        is_public=True,
         sort=sort,
         limit=page_size,
         offset=offset,
     )
 
-    packs = [gear_to_browse_context(g) for g in gear_items if g.is_public]
+    packs = [gear_to_browse_context(g) for g in gear_items]
     total_pages = max(1, ceil(total / page_size))
 
     def build_url(**overrides: object) -> str:
@@ -128,17 +129,19 @@ async def gear_search_fragment(
         query=query,
         gear_type=gear_type,
         manufacturer=manufacturer,
+        is_public=True,
     )
 
     all_gear = await service.search(
         query=query,
         gear_type=gear_type,
         manufacturer=manufacturer,
+        is_public=True,
         limit=limit,
         offset=offset,
     )
 
-    gear_items = [gear for gear in all_gear if gear.is_public]
+    gear_items = list(all_gear)
 
     return templates.TemplateResponse(
         request,

--- a/apps/webapp/src/webapp/api/pages/jobs.py
+++ b/apps/webapp/src/webapp/api/pages/jobs.py
@@ -58,9 +58,9 @@ async def job_detail_page(
     from webapp.services.job_service import JobService
 
     service = JobService(db)
-    job = await service.get_by_id(UUID(job_id))
+    job = await service.get_by_id(UUID(job_id), current_user.id)
 
-    if not job or job.user_id != current_user.id:
+    if job is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Job not found",
@@ -83,11 +83,11 @@ async def job_status_fragment(
     current_user: Annotated[User, Depends(get_current_user_required)],
 ) -> HTMLResponse:
     """Render an HTMX fragment with current job status for the owner."""
-    stmt = select(Job).where(Job.id == job_id)
+    stmt = select(Job).where(Job.id == job_id, Job.user_id == current_user.id)
     result = await db.execute(stmt)
     job = result.scalar_one_or_none()
 
-    if job is None or job.user_id != current_user.id:
+    if job is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
 
     status_value = job.status.value if hasattr(job.status, "value") else str(job.status)

--- a/apps/webapp/src/webapp/api/pages/shootouts.py
+++ b/apps/webapp/src/webapp/api/pages/shootouts.py
@@ -173,7 +173,7 @@ async def shootout_detail_page(
     """Render shootout detail page with full SSR."""
     stmt = (
         select(Shootout)
-        .where(Shootout.id == UUID(shootout_id))
+        .where(Shootout.id == UUID(shootout_id), Shootout.user_id == current_user.id)
         .options(
             joinedload(Shootout.user),
             joinedload(Shootout.di_track),
@@ -183,7 +183,7 @@ async def shootout_detail_page(
     result = await db.execute(stmt)
     shootout_model = result.unique().scalar_one_or_none()
 
-    if not shootout_model or shootout_model.user_id != current_user.id:
+    if shootout_model is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Shootout not found",
@@ -242,8 +242,8 @@ async def shootout_delete_fragment(
     """Delete a shootout via HTMX."""
     service = ShootoutService(db)
 
-    shootout = await service.get_by_id(UUID(shootout_id))
-    if not shootout or shootout.user_id != current_user.id:
+    shootout = await service.get_by_id(UUID(shootout_id), current_user.id)
+    if shootout is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Shootout not found",

--- a/apps/webapp/src/webapp/api/pages/shootouts.py
+++ b/apps/webapp/src/webapp/api/pages/shootouts.py
@@ -409,7 +409,13 @@ async def shootout_comments_fragment(
 ) -> HTMLResponse:
     """Render shootout comments section with real data."""
     comment_repo = ShootoutCommentRepository(db)
-    comments_orm = await comment_repo.list_by_shootout(shootout_id)
+    if current_user is None:
+        # Anonymous requests have no owner to scope by. Public shootout
+        # visibility is introduced by DOM-shootout-visibility; until then
+        # return nothing rather than leak another user's comments.
+        comments_orm: list = []
+    else:
+        comments_orm = await comment_repo.list_by_shootout(shootout_id, current_user.id)
 
     comments = [comment_to_context(c, current_user) for c in comments_orm]
 

--- a/apps/webapp/src/webapp/api/v1/di_tracks.py
+++ b/apps/webapp/src/webapp/api/v1/di_tracks.py
@@ -142,11 +142,11 @@ async def get_di_track(
     """
     from sqlalchemy import select
 
-    stmt = select(DITrack).where(DITrack.id == track_id)
+    stmt = select(DITrack).where(DITrack.id == track_id, DITrack.user_id == current_user.id)
     result = await db.execute(stmt)
     track = result.scalar_one_or_none()
 
-    if not track or track.user_id != current_user.id:
+    if track is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Track not found",
@@ -166,9 +166,9 @@ async def delete_di_track(
     Returns 404 if track not found or not owned by user (avoids leaking existence).
     """
     repo = SQLAlchemyDITrackRepository(db)
-    track = await repo.get_by_id(track_id)
+    track = await repo.get_by_id(track_id, current_user.id)
 
-    if not track or track.user_id != current_user.id:
+    if track is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Track not found",
@@ -201,11 +201,11 @@ async def stream_di_track(
     """
     from sqlalchemy import select
 
-    stmt = select(DITrack).where(DITrack.id == track_id)
+    stmt = select(DITrack).where(DITrack.id == track_id, DITrack.user_id == current_user.id)
     result = await db.execute(stmt)
     track = result.scalar_one_or_none()
 
-    if not track or track.user_id != current_user.id:
+    if track is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Track not found",

--- a/apps/webapp/src/webapp/api/v1/jobs.py
+++ b/apps/webapp/src/webapp/api/v1/jobs.py
@@ -141,11 +141,9 @@ async def get_job(
     """
     service = JobService(db)
 
-    job = await service.get_by_id(job_id)
+    job = await service.get_by_id(job_id, current_user.id)
 
-    # Return 404 if job not found or not owned by user
-    # (Return 404 instead of 403 to avoid leaking existence)
-    if not job or job.user_id != current_user.id:
+    if job is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Job not found",
@@ -190,11 +188,11 @@ async def retry_job(
         HTTPException: 404 if job not found or not owned by user
         HTTPException: 409 if job is not in FAILED status
     """
-    stmt = select(JobModel).where(JobModel.id == job_id)
+    stmt = select(JobModel).where(JobModel.id == job_id, JobModel.user_id == current_user.id)
     result = await db.execute(stmt)
     job_model = result.scalar_one_or_none()
 
-    if not job_model or job_model.user_id != current_user.id:
+    if job_model is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Job not found",

--- a/apps/webapp/src/webapp/api/v1/metrics.py
+++ b/apps/webapp/src/webapp/api/v1/metrics.py
@@ -51,11 +51,15 @@ async def _get_shootout_for_user(
             joinedload(ShootoutModel.chains).joinedload(ShootoutChainModel.signal_chain),
         )
 
-    stmt = select(ShootoutModel).where(ShootoutModel.id == shootout_id).options(*options)
+    stmt = (
+        select(ShootoutModel)
+        .where(ShootoutModel.id == shootout_id, ShootoutModel.user_id == user_id)
+        .options(*options)
+    )
     result = await db.execute(stmt)
     shootout = result.unique().scalar_one_or_none()
 
-    if not shootout or shootout.user_id != user_id:
+    if shootout is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shootout not found")
 
     return shootout

--- a/apps/webapp/src/webapp/api/v1/shootouts.py
+++ b/apps/webapp/src/webapp/api/v1/shootouts.py
@@ -493,6 +493,7 @@ async def list_comments(
     try:
         comments = await service.list_by_shootout(
             shootout_id=shootout_id,
+            user_id=current_user.id,
             limit=limit,
             offset=offset,
         )
@@ -542,11 +543,15 @@ async def delete_comment(
     Raises:
         HTTPException: 404 if shootout or comment not found or not owned by user
     """
-    # Verify shootout exists
+    # Verify shootout exists (existence only). Comment-author ownership is
+    # enforced separately by service.delete below; do NOT reuse the
+    # ownership-scoped list_by_shootout here, or a comment author who does not
+    # own the shootout would be wrongly 404'd.
     service = ShootoutCommentService(db)
-    try:
-        await service.list_by_shootout(shootout_id=shootout_id, limit=1)
-    except ValueError:
+    shootout_exists = (
+        await db.execute(select(ShootoutModel.id).where(ShootoutModel.id == shootout_id))
+    ).scalar_one_or_none()
+    if not shootout_exists:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Shootout not found",

--- a/apps/webapp/src/webapp/api/v1/shootouts.py
+++ b/apps/webapp/src/webapp/api/v1/shootouts.py
@@ -185,11 +185,9 @@ async def get_shootout(
         HTTPException: 404 if shootout not found or not owned by user
     """
     service = ShootoutService(db)
-    shootout = await service.get_by_id(shootout_id)
+    shootout = await service.get_by_id(shootout_id, current_user.id)
 
-    # Return 404 if shootout not found or not owned by user
-    # (Return 404 instead of 403 to avoid leaking existence)
-    if not shootout or shootout.user_id != current_user.id:
+    if shootout is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Shootout not found",
@@ -220,9 +218,9 @@ async def delete_shootout(
     Returns 404 if shootout not found or not owned by user.
     """
     service = ShootoutService(db)
-    shootout = await service.get_by_id(shootout_id)
+    shootout = await service.get_by_id(shootout_id, current_user.id)
 
-    if not shootout or shootout.user_id != current_user.id:
+    if shootout is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Shootout not found",
@@ -255,17 +253,16 @@ async def process_shootout(
         HTTPException: 404 if shootout not found or not owned by user
         HTTPException: 400 if shootout has no chains or is not in DRAFT status
     """
-    # Query shootout with chains
+    # Query shootout with chains, scoped to the owning user
     stmt = (
         select(ShootoutModel)
-        .where(ShootoutModel.id == shootout_id)
+        .where(ShootoutModel.id == shootout_id, ShootoutModel.user_id == current_user.id)
         .options(joinedload(ShootoutModel.chains))
     )
     result = await db.execute(stmt)
     shootout = result.unique().scalar_one_or_none()
 
-    # Return 404 if shootout not found or not owned by user
-    if not shootout or shootout.user_id != current_user.id:
+    if shootout is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Shootout not found",
@@ -324,11 +321,13 @@ async def stream_master_audio(
     current_user: Annotated[User, Depends(get_current_user)],
 ) -> FileResponse:
     """Stream the master FLAC audio file for a completed shootout."""
-    stmt = select(ShootoutModel).where(ShootoutModel.id == shootout_id)
+    stmt = select(ShootoutModel).where(
+        ShootoutModel.id == shootout_id, ShootoutModel.user_id == current_user.id
+    )
     result = await db.execute(stmt)
     shootout = result.scalar_one_or_none()
 
-    if not shootout or shootout.user_id != current_user.id:
+    if shootout is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shootout not found")
 
     if not shootout.output_path:
@@ -370,6 +369,9 @@ async def stream_chain_audio(
         .where(
             ShootoutChainModel.id == chain_id,
             ShootoutChainModel.shootout_id == shootout_id,
+            select(ShootoutModel.id)
+            .where(ShootoutModel.id == shootout_id, ShootoutModel.user_id == current_user.id)
+            .exists(),
         )
         .options(
             joinedload(ShootoutChainModel.shootout),
@@ -379,7 +381,7 @@ async def stream_chain_audio(
     result = await db.execute(stmt)
     chain = result.unique().scalar_one_or_none()
 
-    if not chain or chain.shootout.user_id != current_user.id:
+    if chain is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Chain not found")
 
     if not chain.segments:
@@ -538,8 +540,7 @@ async def delete_comment(
         current_user: Currently authenticated user
 
     Raises:
-        HTTPException: 404 if shootout or comment not found
-        HTTPException: 403 if user is not the comment author
+        HTTPException: 404 if shootout or comment not found or not owned by user
     """
     # Verify shootout exists
     service = ShootoutCommentService(db)
@@ -551,16 +552,11 @@ async def delete_comment(
             detail="Shootout not found",
         )
 
-    # Delete the comment
+    # Delete the comment (ownership enforced at query level)
     try:
         await service.delete(comment_id=comment_id, user_id=current_user.id)
     except ValueError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Comment not found",
-        )
-    except PermissionError:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only the comment author can delete the comment",
         )

--- a/apps/webapp/src/webapp/api/v1/signal_chain_groups.py
+++ b/apps/webapp/src/webapp/api/v1/signal_chain_groups.py
@@ -136,11 +136,9 @@ async def get_signal_chain_group(
         HTTPException: 404 if group not found or not owned by user
     """
     service = SignalChainGroupService(db)
-    group = await service.get_by_id(group_id)
+    group = await service.get_by_id(group_id, current_user.id)
 
-    # Return 404 if group not found or not owned by user
-    # (Return 404 instead of 403 to avoid leaking existence)
-    if not group or group.user_id != current_user.id:
+    if group is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Signal chain group not found",
@@ -185,10 +183,9 @@ async def update_signal_chain_group(
         HTTPException: 404 if group not found or not owned by user
     """
     service = SignalChainGroupService(db)
-    group = await service.get_by_id(group_id)
+    group = await service.get_by_id(group_id, current_user.id)
 
-    # Check ownership
-    if not group or group.user_id != current_user.id:
+    if group is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Signal chain group not found",
@@ -249,9 +246,9 @@ async def generate_permutations(
         HTTPException: 400 if too many permutations
     """
     service = SignalChainGroupService(db)
-    group = await service.get_by_id(group_id)
+    group = await service.get_by_id(group_id, current_user.id)
 
-    if not group or group.user_id != current_user.id:
+    if group is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Signal chain group not found",
@@ -259,7 +256,7 @@ async def generate_permutations(
 
     try:
         async with db.begin():
-            chain_ids = await service.generate_permutations(group_id)
+            chain_ids = await service.generate_permutations(group_id, current_user.id)
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -281,9 +278,9 @@ async def delete_signal_chain_group(
     Returns 404 if group not found or not owned by user.
     """
     service = SignalChainGroupService(db)
-    group = await service.get_by_id(group_id)
+    group = await service.get_by_id(group_id, current_user.id)
 
-    if not group or group.user_id != current_user.id:
+    if group is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Signal chain group not found",

--- a/apps/webapp/src/webapp/api/v1/signal_chains.py
+++ b/apps/webapp/src/webapp/api/v1/signal_chains.py
@@ -206,9 +206,9 @@ async def update_signal_chain(
     """
     service = SignalChainService(db)
 
-    # Get existing chain
-    existing = await service.get_by_id(chain_id)
-    if not existing or existing.user_id != current_user.id:
+    # Get existing chain, scoped to the owning user
+    existing = await service.get_by_id(chain_id, current_user.id)
+    if existing is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Signal chain not found",
@@ -278,9 +278,9 @@ async def delete_signal_chain(
     """
     service = SignalChainService(db)
 
-    # Get existing chain
-    existing = await service.get_by_id(chain_id)
-    if not existing or existing.user_id != current_user.id:
+    # Get existing chain, scoped to the owning user
+    existing = await service.get_by_id(chain_id, current_user.id)
+    if existing is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Signal chain not found",

--- a/apps/webapp/src/webapp/services/job_service.py
+++ b/apps/webapp/src/webapp/services/job_service.py
@@ -32,16 +32,17 @@ class JobService:
         self.session = session
         self.repository = SQLAlchemyJobRepository(session)
 
-    async def get_by_id(self, job_id: UUID) -> Job | None:
-        """Get a job by ID.
+    async def get_by_id(self, job_id: UUID, user_id: UUID) -> Job | None:
+        """Get a job by ID, scoped to the owning user.
 
         Args:
             job_id: Job ID to retrieve
+            user_id: The requesting user's UUID — filters at the query level
 
         Returns:
-            Job entity if found, None otherwise
+            Job entity if found and owned, None otherwise
         """
-        return await self.repository.get_by_id(job_id)
+        return await self.repository.get_by_id(job_id, user_id)
 
     async def get_by_user_id(
         self,

--- a/apps/webapp/src/webapp/services/shootout_comment_service.py
+++ b/apps/webapp/src/webapp/services/shootout_comment_service.py
@@ -109,17 +109,13 @@ class ShootoutCommentService:
 
         Args:
             comment_id: ID of the comment to delete
-            user_id: ID of the user attempting deletion
+            user_id: ID of the user attempting deletion — scopes the lookup
 
         Raises:
-            ValueError: If comment doesn't exist
-            PermissionError: If user is not the comment author
+            ValueError: If comment not found or not owned by user
         """
-        comment = await self.repository.get_by_id(comment_id)
+        comment = await self.repository.get_by_id(comment_id, user_id)
         if not comment:
             raise ValueError("Comment not found")
-
-        if comment.user_id != user_id:
-            raise PermissionError("Only the comment author can delete the comment")
 
         await self.repository.delete(comment_id)

--- a/apps/webapp/src/webapp/services/shootout_comment_service.py
+++ b/apps/webapp/src/webapp/services/shootout_comment_service.py
@@ -73,13 +73,15 @@ class ShootoutCommentService:
     async def list_by_shootout(
         self,
         shootout_id: UUID,
+        user_id: UUID,
         limit: int = 50,
         offset: int = 0,
     ) -> list[ShootoutComment]:
-        """List comments for a shootout, newest first.
+        """List comments for a shootout owned by ``user_id``, newest first.
 
         Args:
             shootout_id: ID of the shootout
+            user_id: The requesting user's UUID; must own the shootout
             limit: Maximum number of comments to return
             offset: Number of comments to skip
 
@@ -87,10 +89,14 @@ class ShootoutCommentService:
             List of comments with user relationship loaded
 
         Raises:
-            ValueError: If shootout doesn't exist
+            ValueError: If shootout doesn't exist or is not owned by user_id
         """
-        # Verify shootout exists
-        stmt = select(Shootout).where(Shootout.id == shootout_id)
+        # Verify the shootout exists AND is owned by the requesting user
+        # (ownership enforced at query level, not a caller-side filter).
+        stmt = select(Shootout).where(
+            Shootout.id == shootout_id,
+            Shootout.user_id == user_id,
+        )
         result = await self.session.execute(stmt)
         shootout = result.scalar_one_or_none()
         if not shootout:
@@ -98,6 +104,7 @@ class ShootoutCommentService:
 
         return await self.repository.list_by_shootout(
             shootout_id=shootout_id,
+            user_id=user_id,
             limit=limit,
             offset=offset,
         )

--- a/apps/webapp/src/webapp/services/shootout_service.py
+++ b/apps/webapp/src/webapp/services/shootout_service.py
@@ -44,16 +44,17 @@ class ShootoutService:
         await self.session.flush()
         return shootout
 
-    async def get_by_id(self, shootout_id: UUID) -> Shootout | None:
-        """Get a shootout by ID.
+    async def get_by_id(self, shootout_id: UUID, user_id: UUID) -> Shootout | None:
+        """Get a shootout by ID, scoped to the owning user.
 
         Args:
             shootout_id: Shootout ID to retrieve
+            user_id: The requesting user's UUID — filters at the query level
 
         Returns:
-            Shootout entity if found, None otherwise
+            Shootout entity if found and owned, None otherwise
         """
-        return await self.repository.get_by_id(shootout_id)
+        return await self.repository.get_by_id(shootout_id, user_id)
 
     async def get_by_user_id(
         self,

--- a/apps/webapp/src/webapp/services/signal_chain_group_service.py
+++ b/apps/webapp/src/webapp/services/signal_chain_group_service.py
@@ -53,16 +53,17 @@ class SignalChainGroupService:
         await self.session.flush()
         return group
 
-    async def get_by_id(self, group_id: UUID) -> SignalChainGroup | None:
-        """Get a signal chain group by ID.
+    async def get_by_id(self, group_id: UUID, user_id: UUID) -> SignalChainGroup | None:
+        """Get a signal chain group by ID, scoped to the owning user.
 
         Args:
             group_id: Group ID to retrieve
+            user_id: The requesting user's UUID — filters at the query level
 
         Returns:
-            SignalChainGroup entity if found, None otherwise
+            SignalChainGroup entity if found and owned, None otherwise
         """
-        return await self.repository.get_by_id(group_id)
+        return await self.repository.get_by_id(group_id, user_id)
 
     async def get_by_user_id(
         self,
@@ -109,7 +110,7 @@ class SignalChainGroupService:
         await self.repository.delete(group_id)
         await self.session.flush()
 
-    async def generate_permutations(self, group_id: UUID) -> list[str]:
+    async def generate_permutations(self, group_id: UUID, user_id: UUID) -> list[str]:
         """Generate signal chain permutations from a group's gear options.
 
         Computes the cartesian product of gear options across slots, then
@@ -117,6 +118,7 @@ class SignalChainGroupService:
 
         Args:
             group_id: ID of the group to generate permutations for
+            user_id: The requesting user's UUID — scopes the group lookup
 
         Returns:
             List of created chain IDs as strings
@@ -124,7 +126,7 @@ class SignalChainGroupService:
         Raises:
             ValueError: If group not found or exceeds max_permutations
         """
-        group = await self.repository.get_by_id(group_id)
+        group = await self.repository.get_by_id(group_id, user_id)
         if group is None:
             raise ValueError(f"Group not found: {group_id}")
 

--- a/apps/webapp/src/webapp/services/signal_chain_group_service.py
+++ b/apps/webapp/src/webapp/services/signal_chain_group_service.py
@@ -152,7 +152,10 @@ class SignalChainGroupService:
         # Look up base chain platform (default to NAM)
         platform_value = Platform.NAM.value
         if group.base_chain_id:
-            stmt = select(SignalChainModel).where(SignalChainModel.id == group.base_chain_id)
+            stmt = select(SignalChainModel).where(
+                SignalChainModel.id == group.base_chain_id,
+                SignalChainModel.user_id == group.user_id,
+            )
             result = await self.session.execute(stmt)
             base_chain = result.scalar_one_or_none()
             if base_chain and base_chain.platform:

--- a/apps/webapp/src/webapp/services/signal_chain_service.py
+++ b/apps/webapp/src/webapp/services/signal_chain_service.py
@@ -73,16 +73,17 @@ class SignalChainService:
 
         return chain
 
-    async def get_by_id(self, chain_id: UUID) -> SignalChain | None:
-        """Get a signal chain by ID.
+    async def get_by_id(self, chain_id: UUID, user_id: UUID) -> SignalChain | None:
+        """Get a signal chain by ID, scoped to the owning user.
 
         Args:
             chain_id: Chain ID to retrieve
+            user_id: The requesting user's UUID — filters at the query level
 
         Returns:
-            SignalChain entity if found, None otherwise
+            SignalChain entity if found and owned, None otherwise
         """
-        return await self.repository.get_by_id(chain_id)
+        return await self.repository.get_by_id(chain_id, user_id)
 
     async def get_by_user_id(
         self, user_id: UUID, limit: int | None = None, offset: int = 0

--- a/model/gts/src/gts/ports/repositories.py
+++ b/model/gts/src/gts/ports/repositories.py
@@ -191,14 +191,15 @@ class GearRepository(Protocol):
 class DITrackRepository(Protocol):
     """Protocol for DI track persistence operations."""
 
-    async def get_by_id(self, track_id: UUID) -> DITrack | None:
-        """Get a DI track by its ID.
+    async def get_by_id(self, track_id: UUID, user_id: UUID) -> DITrack | None:
+        """Get a DI track by its ID, scoped to the owning user.
 
         Args:
             track_id: The track's UUID
+            user_id: The owner's UUID — enforced in the WHERE clause
 
         Returns:
-            The DITrack if found, None otherwise
+            The DITrack if found and owned by user_id, None otherwise
         """
         ...
 
@@ -252,11 +253,12 @@ class DITrackRepository(Protocol):
 class SignalChainRepository(Protocol):
     """Protocol for signal chain persistence operations."""
 
-    async def get_by_id(self, chain_id: UUID) -> SignalChain | None:
-        """Get a signal chain by its ID.
+    async def get_by_id(self, chain_id: UUID, user_id: UUID) -> SignalChain | None:
+        """Get a signal chain by its ID, scoped to the owning user.
 
         Args:
             chain_id: The chain's UUID
+            user_id: The owner's UUID — enforced in the WHERE clause
 
         Returns:
             The SignalChain with all blocks loaded, or None
@@ -317,14 +319,15 @@ class SignalChainRepository(Protocol):
 class SignalChainGroupRepository(Protocol):
     """Protocol for signal chain group persistence operations."""
 
-    async def get_by_id(self, group_id: UUID) -> SignalChainGroup | None:
-        """Get a group by its ID.
+    async def get_by_id(self, group_id: UUID, user_id: UUID) -> SignalChainGroup | None:
+        """Get a group by its ID, scoped to the owning user.
 
         Args:
             group_id: The group's UUID
+            user_id: The owner's UUID — enforced in the WHERE clause
 
         Returns:
-            The SignalChainGroup if found, None otherwise
+            The SignalChainGroup if found and owned by user_id, None otherwise
         """
         ...
 
@@ -367,11 +370,12 @@ class SignalChainGroupRepository(Protocol):
 class ShootoutRepository(Protocol):
     """Protocol for shootout persistence operations."""
 
-    async def get_by_id(self, shootout_id: UUID) -> Shootout | None:
-        """Get a shootout by its ID.
+    async def get_by_id(self, shootout_id: UUID, user_id: UUID) -> Shootout | None:
+        """Get a shootout by its ID, scoped to the owning user.
 
         Args:
             shootout_id: The shootout's UUID
+            user_id: The owner's UUID — enforced in the WHERE clause
 
         Returns:
             The Shootout with all chains loaded, or None
@@ -457,14 +461,15 @@ class ShootoutRepository(Protocol):
 class JobRepository(Protocol):
     """Protocol for job persistence operations."""
 
-    async def get_by_id(self, job_id: UUID) -> Job | None:
-        """Get a job by its ID.
+    async def get_by_id(self, job_id: UUID, user_id: UUID) -> Job | None:
+        """Get a job by its ID, scoped to the owning user.
 
         Args:
             job_id: The job's UUID
+            user_id: The owner's UUID — enforced in the WHERE clause
 
         Returns:
-            The Job if found, None otherwise
+            The Job if found and owned by user_id, None otherwise
         """
         ...
 

--- a/tests/integration/webapp/repositories/test_ownership_enforcement.py
+++ b/tests/integration/webapp/repositories/test_ownership_enforcement.py
@@ -16,6 +16,12 @@ from webapp.adapters.persistence.models.user import User
 from webapp.adapters.persistence.repositories.di_track_repository import (
     SQLAlchemyDITrackRepository,
 )
+from webapp.adapters.persistence.repositories.job_repository import (
+    SQLAlchemyJobRepository,
+)
+from webapp.adapters.persistence.repositories.shootout_comment_repository import (
+    ShootoutCommentRepository,
+)
 from webapp.adapters.persistence.repositories.shootout_repository import (
     SQLAlchemyShootoutRepository,
 )
@@ -180,4 +186,82 @@ async def test_di_track_get_by_id_rejects_wrong_user(db_session: AsyncSession) -
     assert found.id == entity.id
 
     not_found = await repo.get_by_id(entity.id, other.id)
+    assert not_found is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_job_get_by_id_rejects_wrong_user(db_session: AsyncSession) -> None:
+    """get_by_id returns None when user_id does not match the record owner."""
+    from gts.domain.entities.job import Job as JobEntity
+    from gts.domain.value_objects.job_status import JobType
+
+    suffix = uuid4().hex[:8]
+    owner = await _create_user(db_session, f"owner_{suffix}")
+    other = await _create_user(db_session, f"other_{suffix}")
+
+    entity = JobEntity(
+        id=uuid4(),
+        user_id=owner.id,
+        job_type=JobType.AUDIO_PROCESSING,
+    )
+    repo = SQLAlchemyJobRepository(db_session)
+    await repo.save(entity)
+    await db_session.flush()
+
+    found = await repo.get_by_id(entity.id, owner.id)
+    assert found is not None
+    assert found.id == entity.id
+
+    not_found = await repo.get_by_id(entity.id, other.id)
+    assert not_found is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_shootout_comment_get_by_id_rejects_wrong_user(db_session: AsyncSession) -> None:
+    """get_by_id returns None when user_id does not match the comment author."""
+    from webapp.adapters.persistence.models.shootout import DITrack, Shootout
+    from webapp.adapters.persistence.models.shootout_comment import ShootoutComment
+
+    suffix = uuid4().hex[:8]
+    owner = await _create_user(db_session, f"owner_{suffix}")
+    other = await _create_user(db_session, f"other_{suffix}")
+
+    di_track = DITrack(
+        id=uuid4(),
+        user_id=owner.id,
+        name="DI",
+        file_path="/audio/di.wav",
+        original_filename="di.wav",
+        duration_seconds=30.0,
+        sample_rate=44100,
+    )
+    db_session.add(di_track)
+    shootout = Shootout(
+        id=uuid4(),
+        user_id=owner.id,
+        name="Shootout",
+        di_track_id=di_track.id,
+    )
+    db_session.add(shootout)
+    await db_session.flush()
+
+    comment = ShootoutComment(
+        id=uuid4(),
+        shootout_id=shootout.id,
+        user_id=owner.id,
+        content="Owner's comment",
+    )
+    db_session.add(comment)
+    await db_session.flush()
+    comment_id = comment.id
+
+    repo = ShootoutCommentRepository(db_session)
+
+    found = await repo.get_by_id(comment_id, owner.id)
+    assert found is not None
+    assert found.id == comment_id
+
+    not_found = await repo.get_by_id(comment_id, other.id)
     assert not_found is None

--- a/tests/integration/webapp/repositories/test_ownership_enforcement.py
+++ b/tests/integration/webapp/repositories/test_ownership_enforcement.py
@@ -1,0 +1,183 @@
+"""Cross-user isolation tests for repository ownership enforcement.
+
+Verifies that get_by_id methods on user-owned resource repositories enforce
+ownership at the query level: a query with the wrong user_id returns None,
+not another user's data.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+
+from webapp.adapters.persistence.models.user import User
+from webapp.adapters.persistence.repositories.di_track_repository import (
+    SQLAlchemyDITrackRepository,
+)
+from webapp.adapters.persistence.repositories.shootout_repository import (
+    SQLAlchemyShootoutRepository,
+)
+from webapp.adapters.persistence.repositories.signal_chain_group_repository import (
+    SQLAlchemySignalChainGroupRepository,
+)
+from webapp.adapters.persistence.repositories.signal_chain_repository import (
+    SQLAlchemySignalChainRepository,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def _create_user(db_session: AsyncSession, suffix: str) -> User:
+    user = User(
+        id=uuid4(),
+        username=f"owner_{suffix}",
+        email=f"owner_{suffix}@example.com",
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_shootout_get_by_id_rejects_wrong_user(db_session: AsyncSession) -> None:
+    """get_by_id returns None when user_id does not match the record owner."""
+    from gts.domain.entities.shootout import Shootout as ShootoutEntity
+    from gts.domain.value_objects.signal_chain_enums import Platform
+    from webapp.adapters.persistence.models.shootout import DITrack
+    from webapp.adapters.persistence.models.signal_chain import SignalChain
+
+    suffix = uuid4().hex[:8]
+    owner = await _create_user(db_session, f"owner_{suffix}")
+    other = await _create_user(db_session, f"other_{suffix}")
+
+    di_track = DITrack(
+        id=uuid4(),
+        user_id=owner.id,
+        name="DI Track",
+        file_path="/audio/di.wav",
+        original_filename="di.wav",
+        duration_seconds=30.0,
+        sample_rate=44100,
+    )
+    db_session.add(di_track)
+
+    chain = SignalChain(id=uuid4(), user_id=owner.id, name="Chain", platform=Platform.NAM)
+    db_session.add(chain)
+
+    await db_session.flush()
+
+    entity = ShootoutEntity(
+        id=uuid4(),
+        user_id=owner.id,
+        name="Owned Shootout",
+        di_track_id=di_track.id,
+    )
+    repo = SQLAlchemyShootoutRepository(db_session)
+    await repo.save(entity)
+    await db_session.flush()
+
+    # Owner can fetch it
+    found = await repo.get_by_id(entity.id, owner.id)
+    assert found is not None
+    assert found.id == entity.id
+
+    # Different user gets None — cross-user isolation enforced at query level
+    not_found = await repo.get_by_id(entity.id, other.id)
+    assert not_found is None
+
+    # Non-existent ID also returns None
+    assert await repo.get_by_id(uuid4(), owner.id) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_signal_chain_get_by_id_rejects_wrong_user(db_session: AsyncSession) -> None:
+    """get_by_id returns None when user_id does not match the record owner."""
+    from gts.domain.entities.signal_chain import SignalChain as SignalChainEntity
+    from gts.domain.value_objects.signal_chain_enums import Platform
+
+    suffix = uuid4().hex[:8]
+    owner = await _create_user(db_session, f"owner_{suffix}")
+    other = await _create_user(db_session, f"other_{suffix}")
+
+    entity = SignalChainEntity(
+        id=uuid4(),
+        user_id=owner.id,
+        name="Owned Chain",
+        platform=Platform.NAM,
+    )
+    repo = SQLAlchemySignalChainRepository(db_session)
+    await repo.save(entity)
+    await db_session.flush()
+
+    found = await repo.get_by_id(entity.id, owner.id)
+    assert found is not None
+    assert found.id == entity.id
+
+    not_found = await repo.get_by_id(entity.id, other.id)
+    assert not_found is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_signal_chain_group_get_by_id_rejects_wrong_user(db_session: AsyncSession) -> None:
+    """get_by_id returns None when user_id does not match the record owner."""
+    from gts.domain.entities.signal_chain_group import SignalChainGroup
+
+    suffix = uuid4().hex[:8]
+    owner = await _create_user(db_session, f"owner_{suffix}")
+    other = await _create_user(db_session, f"other_{suffix}")
+
+    entity = SignalChainGroup(
+        id=uuid4(),
+        user_id=owner.id,
+        name="Owned Group",
+        slot_positions=[0, 1],
+        gear_options={},
+    )
+    repo = SQLAlchemySignalChainGroupRepository(db_session)
+    await repo.save(entity)
+    await db_session.flush()
+
+    found = await repo.get_by_id(entity.id, owner.id)
+    assert found is not None
+    assert found.id == entity.id
+
+    not_found = await repo.get_by_id(entity.id, other.id)
+    assert not_found is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_di_track_get_by_id_rejects_wrong_user(db_session: AsyncSession) -> None:
+    """get_by_id returns None when user_id does not match the record owner."""
+    from gts.domain.entities.di_track import DITrack as DITrackEntity
+
+    suffix = uuid4().hex[:8]
+    owner = await _create_user(db_session, f"owner_{suffix}")
+    other = await _create_user(db_session, f"other_{suffix}")
+
+    entity = DITrackEntity(
+        id=uuid4(),
+        user_id=owner.id,
+        name="Owned DI Track",
+        file_path="/audio/owned.wav",
+        original_filename="owned.wav",
+        duration_seconds=30.0,
+        sample_rate=44100,
+        checksum=None,
+    )
+    repo = SQLAlchemyDITrackRepository(db_session)
+    await repo.save(entity)
+    await db_session.flush()
+
+    found = await repo.get_by_id(entity.id, owner.id)
+    assert found is not None
+    assert found.id == entity.id
+
+    not_found = await repo.get_by_id(entity.id, other.id)
+    assert not_found is None

--- a/tests/integration/webapp/repositories/test_shootout_repository.py
+++ b/tests/integration/webapp/repositories/test_shootout_repository.py
@@ -151,19 +151,23 @@ async def test_shootout_get_by_id_single_query(
     await shootout_repository.save(shootout_entity)
     await db_session.commit()
 
+    # Capture IDs before expire_all() to avoid lazy-load in async context
+    shootout_id = shootout_entity.id
+    owner_user_id = test_user.id
+
     # Expire all objects to force fresh queries
     db_session.expire_all()
 
-    # Execute get_by_id
+    # Execute get_by_id with owner's user_id
     with QueryCounter(db_engine) as counter:
-        result = await shootout_repository.get_by_id(shootout_entity.id)
+        result = await shootout_repository.get_by_id(shootout_id, owner_user_id)
 
     # Acceptance Criteria: query count = 1
     assert counter.count == 1, f"Expected 1 query (single SELECT with JOIN), got {counter.count}"
 
     # Acceptance Criteria: verify correct entity returned
     assert result is not None, "Expected shootout to be found"
-    assert result.id == shootout_entity.id, "Expected correct shootout ID"
+    assert result.id == shootout_id, "Expected correct shootout ID"
     assert result.name == "Test Shootout", "Expected correct shootout name"
 
     # Acceptance Criteria: verify relationships loaded correctly

--- a/tests/integration/webapp/repositories/test_signal_chain_repository.py
+++ b/tests/integration/webapp/repositories/test_signal_chain_repository.py
@@ -145,9 +145,11 @@ async def test_signal_chain_get_by_id_single_query(
     # Expire all objects to force fresh query
     db_session.expire_all()
 
-    # Count queries during get_by_id
+    # Count queries during get_by_id (with owner's user_id)
     with QueryCounter(db_engine) as counter:
-        result = await signal_chain_repository.get_by_id(sample_signal_chain_with_blocks.id)
+        result = await signal_chain_repository.get_by_id(
+            sample_signal_chain_with_blocks.id, sample_signal_chain_with_blocks.user_id
+        )
 
     # Verify chain loaded
     assert result is not None
@@ -186,8 +188,10 @@ async def test_signal_chain_get_by_id_uses_unique(
     # Expire all objects
     db_session.expire_all()
 
-    # Execute get_by_id
-    result = await signal_chain_repository.get_by_id(sample_signal_chain_with_blocks.id)
+    # Execute get_by_id (with owner's user_id)
+    result = await signal_chain_repository.get_by_id(
+        sample_signal_chain_with_blocks.id, sample_signal_chain_with_blocks.user_id
+    )
 
     # Verify no duplicates: should return single entity, not multiple
     assert result is not None

--- a/tests/integration/webapp/test_job_service.py
+++ b/tests/integration/webapp/test_job_service.py
@@ -50,7 +50,7 @@ async def test_get_job_by_id_returns_job(
         await repo.save(job)
 
     # Retrieve job
-    retrieved = await service.get_by_id(job.id)
+    retrieved = await service.get_by_id(job.id, job.user_id)
 
     assert retrieved is not None
     assert retrieved.id == job.id
@@ -65,7 +65,7 @@ async def test_get_job_by_id_returns_none_for_missing(
     """Test getting a non-existent job returns None."""
     service = JobService(db_session)
 
-    result = await service.get_by_id(uuid4())
+    result = await service.get_by_id(uuid4(), uuid4())
 
     assert result is None
 

--- a/tests/integration/webapp/test_repositories.py
+++ b/tests/integration/webapp/test_repositories.py
@@ -102,7 +102,7 @@ async def test_di_track_save_and_get_by_id(
     await db_session.commit()
 
     # Retrieve track
-    retrieved = await repo.get_by_id(track.id)
+    retrieved = await repo.get_by_id(track.id, track.user_id)
 
     # Verify
     assert retrieved is not None
@@ -248,7 +248,7 @@ async def test_shootout_save_and_get_by_id(
     await db_session.commit()
 
     # Retrieve shootout
-    retrieved = await repo.get_by_id(shootout.id)
+    retrieved = await repo.get_by_id(shootout.id, shootout.user_id)
 
     # Verify
     assert retrieved is not None
@@ -340,7 +340,7 @@ async def test_job_save_and_get_by_id(
     await db_session.commit()
 
     # Retrieve job
-    retrieved = await repo.get_by_id(job.id)
+    retrieved = await repo.get_by_id(job.id, job.user_id)
 
     # Verify
     assert retrieved is not None
@@ -531,7 +531,7 @@ async def test_signal_chain_group_save_and_get_by_id(
     await db_session.commit()
 
     # Retrieve group
-    retrieved = await repo.get_by_id(group.id)
+    retrieved = await repo.get_by_id(group.id, group.user_id)
 
     # Verify
     assert retrieved is not None

--- a/tests/integration/webapp/test_shootout_comments_api.py
+++ b/tests/integration/webapp/test_shootout_comments_api.py
@@ -379,7 +379,7 @@ class TestDeleteComment:
 
         assert response.status_code == 404
 
-    async def test_delete_comment_returns_403_for_non_author(
+    async def test_delete_comment_returns_404_for_non_author(
         self,
         app: FastAPI,
         db_session: AsyncSession,
@@ -387,7 +387,7 @@ class TestDeleteComment:
         other_user: User,
         test_shootout: Shootout,
     ) -> None:
-        """DELETE returns 403 when user is not the comment author."""
+        """DELETE returns 404 when user is not the comment author (ownership enforced at query level)."""
         comment = ShootoutComment(
             shootout_id=test_shootout.id,
             user_id=test_user.id,
@@ -408,7 +408,7 @@ class TestDeleteComment:
         set_session_override(None)
         set_user_override(None)
 
-        assert response.status_code == 403
+        assert response.status_code == 404
 
     async def test_delete_comment_returns_404_for_missing_shootout(
         self,

--- a/tests/integration/webapp/test_shootout_repository.py
+++ b/tests/integration/webapp/test_shootout_repository.py
@@ -187,7 +187,7 @@ async def test_get_by_id_returns_entity_with_chains(
     await db_session.commit()
 
     # Retrieve entity
-    retrieved = await repo.get_by_id(shootout.id)
+    retrieved = await repo.get_by_id(shootout.id, shootout.user_id)
 
     assert retrieved is not None
     assert retrieved.id == shootout.id
@@ -204,7 +204,7 @@ async def test_get_by_id_returns_none_for_missing(
     """Test retrieving a non-existent shootout returns None."""
     repo = SQLAlchemyShootoutRepository(db_session)
 
-    result = await repo.get_by_id(uuid4())
+    result = await repo.get_by_id(uuid4(), uuid4())
 
     assert result is None
 
@@ -428,7 +428,7 @@ async def test_delete_removes_shootout(
     await db_session.commit()
 
     # Verify deletion
-    result = await repo.get_by_id(shootout_id)
+    result = await repo.get_by_id(shootout_id, test_user.id)
     assert result is None
 
 
@@ -576,7 +576,7 @@ async def test_entity_mapping_preserves_processed_status(
     await db_session.commit()
 
     # Retrieve and verify
-    retrieved = await repo.get_by_id(shootout.id)
+    retrieved = await repo.get_by_id(shootout.id, shootout.user_id)
 
     assert retrieved is not None
     assert retrieved.is_processed is True
@@ -602,7 +602,7 @@ async def test_entity_mapping_sets_default_output_format(
     await repo.save(shootout)
     await db_session.commit()
 
-    retrieved = await repo.get_by_id(shootout.id)
+    retrieved = await repo.get_by_id(shootout.id, shootout.user_id)
 
     assert retrieved is not None
     assert retrieved.output_format == "mp4"

--- a/tests/integration/webapp/test_shootout_service.py
+++ b/tests/integration/webapp/test_shootout_service.py
@@ -85,7 +85,7 @@ async def test_get_shootout_by_id_returns_entity(
         await service.create(shootout)
 
     # Retrieve shootout
-    retrieved = await service.get_by_id(shootout.id)
+    retrieved = await service.get_by_id(shootout.id, shootout.user_id)
 
     assert retrieved is not None
     assert retrieved.id == shootout.id
@@ -100,7 +100,7 @@ async def test_get_shootout_by_id_returns_none_for_missing(
     """Test retrieving a non-existent shootout returns None."""
     service = ShootoutService(db_session)
 
-    result = await service.get_by_id(uuid4())
+    result = await service.get_by_id(uuid4(), uuid4())
 
     assert result is None
 
@@ -194,7 +194,7 @@ async def test_update_shootout_persists_changes(
     assert updated.description == "New description"
 
     # Verify persisted
-    retrieved = await service.get_by_id(shootout.id)
+    retrieved = await service.get_by_id(shootout.id, shootout.user_id)
     assert retrieved is not None
     assert retrieved.name == "Updated Name"
 
@@ -225,7 +225,7 @@ async def test_delete_shootout_removes_from_database(
         await service.delete(shootout_id)
 
     # Verify deletion
-    result = await service.get_by_id(shootout_id)
+    result = await service.get_by_id(shootout_id, test_user.id)
     assert result is None
 
 
@@ -263,7 +263,7 @@ async def test_add_chain_to_shootout_persists_association(
         await service.update(shootout)
 
     # Verify chain persisted
-    retrieved = await service.get_by_id(shootout.id)
+    retrieved = await service.get_by_id(shootout.id, shootout.user_id)
     assert retrieved is not None
     assert len(retrieved.chains) == 1
     assert retrieved.chains[0].signal_chain_id == test_signal_chain.id
@@ -295,7 +295,7 @@ async def test_mark_processed_updates_status(
         await service.update(shootout)
 
     # Verify processed status
-    retrieved = await service.get_by_id(shootout.id)
+    retrieved = await service.get_by_id(shootout.id, shootout.user_id)
     assert retrieved is not None
     assert retrieved.is_processed is True
     assert retrieved.output_path == "/path/to/video.mp4"

--- a/tests/integration/webapp/test_shootouts_api.py
+++ b/tests/integration/webapp/test_shootouts_api.py
@@ -224,7 +224,7 @@ async def test_create_shootout_persists_to_database(
     service = ShootoutService(db_session)
     from uuid import UUID
 
-    saved = await service.get_by_id(UUID(shootout_id))
+    saved = await service.get_by_id(UUID(shootout_id), test_user.id)
     assert saved is not None
     assert saved.name == "New Shootout"
 

--- a/tests/integration/webapp/test_signal_chain_group_crud.py
+++ b/tests/integration/webapp/test_signal_chain_group_crud.py
@@ -134,7 +134,7 @@ class TestSignalChainGroupService:
         async with db_session.begin():
             await service.create(group)
 
-        retrieved = await service.get_by_id(group.id)
+        retrieved = await service.get_by_id(group.id, group.user_id)
 
         assert retrieved is not None
         assert retrieved.id == group.id
@@ -148,7 +148,7 @@ class TestSignalChainGroupService:
         """Test get_by_id returns None for non-existent group."""
         service = SignalChainGroupService(db_session)
 
-        result = await service.get_by_id(uuid4())
+        result = await service.get_by_id(uuid4(), uuid4())
 
         assert result is None
 
@@ -217,7 +217,7 @@ class TestSignalChainGroupService:
         assert updated.description == "Updated description"
 
         # Verify persistence
-        retrieved = await service.get_by_id(group.id)
+        retrieved = await service.get_by_id(group.id, group.user_id)
         assert retrieved is not None
         assert retrieved.name == "Updated Name"
         assert retrieved.description == "Updated description"
@@ -243,14 +243,14 @@ class TestSignalChainGroupService:
             await service.create(group)
 
         # Verify it exists
-        assert await service.get_by_id(group.id) is not None
+        assert await service.get_by_id(group.id, group.user_id) is not None
 
         # Delete
         async with db_session.begin():
             await service.delete(group.id)
 
         # Verify deletion
-        assert await service.get_by_id(group.id) is None
+        assert await service.get_by_id(group.id, group.user_id) is None
 
 
 # API Tests
@@ -489,7 +489,7 @@ class TestSignalChainGroupAPI:
         assert response.status_code == 204
 
         # Verify deletion
-        retrieved = await service.get_by_id(group.id)
+        retrieved = await service.get_by_id(group.id, group.user_id)
         assert retrieved is None
 
     async def test_delete_group_ownership_check(
@@ -518,7 +518,7 @@ class TestSignalChainGroupAPI:
         assert response.status_code == 404
 
         # Verify group still exists
-        retrieved = await service.get_by_id(group.id)
+        retrieved = await service.get_by_id(group.id, group.user_id)
         assert retrieved is not None
 
     async def test_create_requires_authentication(

--- a/tests/integration/webapp/test_signal_chain_group_permutations.py
+++ b/tests/integration/webapp/test_signal_chain_group_permutations.py
@@ -294,7 +294,7 @@ class TestSignalChainGroupPermutations:
         service = SignalChainGroupService(db_session)
 
         async with db_session.begin():
-            result = await service.generate_permutations(group_with_2x2.id)
+            result = await service.generate_permutations(group_with_2x2.id, group_with_2x2.user_id)
 
         # Should return 4 chain IDs (2 amps × 2 IRs)
         assert len(result) == 4
@@ -320,7 +320,9 @@ class TestSignalChainGroupPermutations:
         service = SignalChainGroupService(db_session)
 
         async with db_session.begin():
-            chain_ids = await service.generate_permutations(group_with_2x2.id)
+            chain_ids = await service.generate_permutations(
+                group_with_2x2.id, group_with_2x2.user_id
+            )
 
         # Verify chain names contain the group name
         stmt = select(SignalChain).where(
@@ -385,7 +387,7 @@ class TestSignalChainGroupPermutations:
         # Should raise error or return error result
         async with db_session.begin():
             with pytest.raises(Exception) as exc_info:
-                await service.generate_permutations(group.id)
+                await service.generate_permutations(group.id, group.user_id)
 
             # Error should mention max permutations
             assert (
@@ -443,7 +445,7 @@ class TestSignalChainGroupPermutations:
         service = SignalChainGroupService(db_session)
 
         async with db_session.begin():
-            chain_ids = await service.generate_permutations(group.id)
+            chain_ids = await service.generate_permutations(group.id, group.user_id)
 
         # Should create 2 chains (2 amps × 1 null option for slot 1)
         assert len(chain_ids) == 2
@@ -458,7 +460,9 @@ class TestSignalChainGroupPermutations:
         service = SignalChainGroupService(db_session)
 
         async with db_session.begin():
-            chain_ids = await service.generate_permutations(group_with_2x2.id)
+            chain_ids = await service.generate_permutations(
+                group_with_2x2.id, group_with_2x2.user_id
+            )
 
         # Verify chains exist and are valid
         stmt = select(SignalChain).where(

--- a/tests/integration/webapp/test_signal_chain_groups_router_mount_t123.py
+++ b/tests/integration/webapp/test_signal_chain_groups_router_mount_t123.py
@@ -313,7 +313,7 @@ class TestSignalChainGroupsRouterMount:
         assert response.status_code == 204
 
         # Verify deletion
-        retrieved = await service.get_by_id(group.id)
+        retrieved = await service.get_by_id(group.id, group.user_id)
         assert retrieved is None
 
     async def test_generate_endpoint_requires_authentication(

--- a/tests/integration/webapp/test_signal_chain_repository.py
+++ b/tests/integration/webapp/test_signal_chain_repository.py
@@ -61,7 +61,7 @@ async def test_save_new_chain(
     await session.commit()
 
     # Verify it was saved
-    retrieved = await repo.get_by_id(sample_chain.id)
+    retrieved = await repo.get_by_id(sample_chain.id, sample_chain.user_id)
     assert retrieved is not None
     assert retrieved.id == sample_chain.id
     assert retrieved.name == "Test Chain"
@@ -101,7 +101,7 @@ async def test_save_update_chain(
     session.expire_all()
 
     # Verify the update
-    retrieved = await repo.get_by_id(sample_chain.id)
+    retrieved = await repo.get_by_id(sample_chain.id, sample_chain.user_id)
     assert retrieved is not None
     assert retrieved.name == "Updated Chain"
     assert retrieved.description == "Updated description"
@@ -143,7 +143,7 @@ async def test_save_with_multiple_blocks(
     await session.commit()
 
     # Verify all blocks were saved
-    retrieved = await repo.get_by_id(sample_chain.id)
+    retrieved = await repo.get_by_id(sample_chain.id, sample_chain.user_id)
     assert retrieved is not None
     assert len(retrieved.blocks) == 3
     assert retrieved.blocks[0].position == 0
@@ -205,7 +205,7 @@ async def test_update_blocks(
     session.expire_all()
 
     # Verify blocks were updated
-    retrieved = await repo.get_by_id(sample_chain.id)
+    retrieved = await repo.get_by_id(sample_chain.id, sample_chain.user_id)
     assert retrieved is not None
     assert len(retrieved.blocks) == 2
     assert retrieved.blocks[0].id == block1.id
@@ -329,7 +329,7 @@ async def test_delete_chain(
     await session.commit()
 
     # Verify it was deleted
-    retrieved = await repo.get_by_id(sample_chain.id)
+    retrieved = await repo.get_by_id(sample_chain.id, sample_chain.user_id)
     assert retrieved is None
 
 
@@ -347,7 +347,7 @@ async def test_get_nonexistent_chain(session: AsyncSession) -> None:
     repo = SQLAlchemySignalChainRepository(session)
 
     # Get nonexistent chain
-    retrieved = await repo.get_by_id(uuid.uuid4())
+    retrieved = await repo.get_by_id(uuid.uuid4(), uuid.uuid4())
     assert retrieved is None
 
 
@@ -387,7 +387,7 @@ async def test_blocks_sorted_by_position(
     await session.commit()
 
     # Verify blocks are sorted by position
-    retrieved = await repo.get_by_id(sample_chain.id)
+    retrieved = await repo.get_by_id(sample_chain.id, sample_chain.user_id)
     assert retrieved is not None
     assert len(retrieved.blocks) == 3
     assert retrieved.blocks[0].position == 0

--- a/tests/regression/test_phase4_completion.py
+++ b/tests/regression/test_phase4_completion.py
@@ -134,8 +134,8 @@ class TestShootoutCommentRoundTrip:
         )
         await db_session.commit()
 
-        # List comments
-        comments = await comment_repo.list_by_shootout(shootout.id)
+        # List comments (scoped to the owning user)
+        comments = await comment_repo.list_by_shootout(shootout.id, user.id)
         assert len(comments) == 2
         # Newest first
         assert comments[0].content == "Second comment"

--- a/tests/regression/test_phase4_completion.py
+++ b/tests/regression/test_phase4_completion.py
@@ -100,7 +100,7 @@ class TestShootoutCommentRoundTrip:
         await db_session.commit()
 
         # Retrieve and verify
-        retrieved = await comment_repo.get_by_id(comment.id)
+        retrieved = await comment_repo.get_by_id(comment.id, user.id)
         assert retrieved is not None
         assert retrieved.id == comment.id
         assert retrieved.shootout_id == shootout.id

--- a/tests/regression/test_stack.py
+++ b/tests/regression/test_stack.py
@@ -101,14 +101,19 @@ class TestJobRoundTrip:
     @pytest.mark.asyncio
     async def test_create_and_retrieve(self, db_session: AsyncSession) -> None:
         """Create job via repository, retrieve it - validates Job stack."""
-        job = JobEntity(job_type=JobType.AUDIO_PROCESSING, message="Test job")
+        user = User(username="regression_job_user", email="job@regression.dev")
+        db_session.add(user)
+        await db_session.flush()
+        user_id = user.id
+
+        job = JobEntity(user_id=user_id, job_type=JobType.AUDIO_PROCESSING, message="Test job")
         original_id = job.id
 
         repo = SQLAlchemyJobRepository(db_session)
         await repo.save(job)
         await db_session.commit()
 
-        retrieved = await repo.get_by_id(original_id)
+        retrieved = await repo.get_by_id(original_id, user_id)
 
         assert retrieved is not None, "Job should be retrievable"
         assert retrieved.id == original_id
@@ -119,7 +124,12 @@ class TestJobRoundTrip:
     @pytest.mark.asyncio
     async def test_job_state_transitions(self, db_session: AsyncSession) -> None:
         """Job state machine works correctly."""
-        job = JobEntity(job_type=JobType.AUDIO_PROCESSING)
+        user = User(username="regression_state_user", email="state@regression.dev")
+        db_session.add(user)
+        await db_session.flush()
+        user_id = user.id
+
+        job = JobEntity(user_id=user_id, job_type=JobType.AUDIO_PROCESSING)
 
         # Queue the job
         job.queue(task_id="test-task-123")
@@ -146,7 +156,7 @@ class TestJobRoundTrip:
         await repo.save(job)
         await db_session.commit()
 
-        retrieved = await repo.get_by_id(job.id)
+        retrieved = await repo.get_by_id(job.id, user_id)
         assert retrieved is not None
         assert retrieved.status == JobStatus.COMPLETED
         assert retrieved.result_path == "/results/test.wav"

--- a/tests/unit/webapp/test_shootout_comment_repository.py
+++ b/tests/unit/webapp/test_shootout_comment_repository.py
@@ -131,7 +131,7 @@ class TestShootoutCommentRepositoryListByShootout:
         session.add_all([comment1, comment2])
         await session.commit()
 
-        comments = await repository.list_by_shootout(shootout.id)
+        comments = await repository.list_by_shootout(shootout.id, user.id)
 
         assert len(comments) == 2
         # Newest first means second comment appears first
@@ -142,10 +142,11 @@ class TestShootoutCommentRepositoryListByShootout:
     async def test_list_by_shootout_returns_empty_for_no_comments(
         self,
         repository: ShootoutCommentRepository,
+        user: User,
         shootout: Shootout,
     ) -> None:
         """Repository.list_by_shootout returns empty list when no comments exist."""
-        comments = await repository.list_by_shootout(shootout.id)
+        comments = await repository.list_by_shootout(shootout.id, user.id)
         assert comments == []
 
     @pytest.mark.asyncio
@@ -193,10 +194,55 @@ class TestShootoutCommentRepositoryListByShootout:
         session.add_all([other_comment, our_comment])
         await session.commit()
 
-        comments = await repository.list_by_shootout(shootout.id)
+        comments = await repository.list_by_shootout(shootout.id, user.id)
 
         assert len(comments) == 1
         assert comments[0].content == "Our shootout comment"
+
+    @pytest.mark.asyncio
+    async def test_list_by_shootout_never_leaks_another_owners_comments(
+        self,
+        repository: ShootoutCommentRepository,
+        session: AsyncSession,
+        user: User,
+        other_user: User,
+    ) -> None:
+        """list_by_shootout returns nothing when user_id is not the shootout
+        owner - comments never cross the owner boundary (query-level ownership)."""
+        di_track = DITrack(
+            user_id=other_user.id,
+            name="Other owner DI",
+            file_path="/path/to/other-owner.wav",
+            original_filename="other-owner.wav",
+            duration_seconds=20.0,
+            sample_rate=48000,
+        )
+        session.add(di_track)
+        await session.commit()
+
+        other_shootout = Shootout(
+            user_id=other_user.id,
+            di_track_id=di_track.id,
+            name="Other owner shootout",
+            status=ShootoutStatus.PENDING,
+        )
+        session.add(other_shootout)
+        await session.commit()
+
+        # A comment exists on the other owner's shootout (even authored by `user`).
+        session.add(
+            ShootoutComment(
+                shootout_id=other_shootout.id,
+                user_id=user.id,
+                content="should not leak to non-owner",
+            )
+        )
+        await session.commit()
+
+        # `user` does not own other_shootout, so the ownership-scoped read
+        # returns nothing despite the comment existing on it.
+        comments = await repository.list_by_shootout(other_shootout.id, user.id)
+        assert comments == []
 
     @pytest.mark.asyncio
     async def test_list_by_shootout_supports_pagination(
@@ -217,11 +263,11 @@ class TestShootoutCommentRepositoryListByShootout:
         await session.commit()
 
         # Get first page
-        page1 = await repository.list_by_shootout(shootout.id, limit=2, offset=0)
+        page1 = await repository.list_by_shootout(shootout.id, user.id, limit=2, offset=0)
         assert len(page1) == 2
 
         # Get second page
-        page2 = await repository.list_by_shootout(shootout.id, limit=2, offset=2)
+        page2 = await repository.list_by_shootout(shootout.id, user.id, limit=2, offset=2)
         assert len(page2) == 2
 
         # Ensure no overlap
@@ -246,7 +292,7 @@ class TestShootoutCommentRepositoryListByShootout:
         session.add(comment)
         await session.commit()
 
-        comments = await repository.list_by_shootout(shootout.id)
+        comments = await repository.list_by_shootout(shootout.id, user.id)
 
         assert len(comments) == 1
         # Should be able to access user without lazy loading error

--- a/tests/unit/webapp/test_shootout_comment_repository.py
+++ b/tests/unit/webapp/test_shootout_comment_repository.py
@@ -297,9 +297,12 @@ class TestShootoutCommentRepositoryDelete:
             content="Find me",
         )
         session.add(comment)
+        await session.flush()
+        comment_id = comment.id
+        owner_user_id = comment.user_id
         await session.commit()
 
-        found = await repository.get_by_id(comment.id)
+        found = await repository.get_by_id(comment_id, owner_user_id)
 
         assert found is not None
         assert found.id == comment.id
@@ -311,5 +314,5 @@ class TestShootoutCommentRepositoryDelete:
         repository: ShootoutCommentRepository,
     ) -> None:
         """Repository.get_by_id returns None for non-existent comment."""
-        found = await repository.get_by_id(uuid4())
+        found = await repository.get_by_id(uuid4(), uuid4())
         assert found is None

--- a/tests/unit/webapp/test_shootout_comment_service.py
+++ b/tests/unit/webapp/test_shootout_comment_service.py
@@ -307,17 +307,19 @@ class TestShootoutCommentServiceDelete:
         other_user: User,
         shootout: Shootout,
     ) -> None:
-        """Service.delete raises PermissionError when user is not the comment author."""
+        """Service.delete raises ValueError when user is not the comment author (ownership enforced at query level)."""
         comment = ShootoutComment(
             shootout_id=shootout.id,
             user_id=user.id,
             content="Not yours to delete",
         )
         session.add(comment)
+        await session.flush()
+        comment_id = comment.id
         await session.commit()
 
-        with pytest.raises(PermissionError):
-            await service.delete(comment_id=comment.id, user_id=other_user.id)
+        with pytest.raises(ValueError):
+            await service.delete(comment_id=comment_id, user_id=other_user.id)
 
     @pytest.mark.asyncio
     async def test_delete_does_not_remove_other_users_comment(
@@ -335,10 +337,11 @@ class TestShootoutCommentServiceDelete:
             content="Still here",
         )
         session.add(comment)
-        await session.commit()
+        await session.flush()
         comment_id = comment.id
+        await session.commit()
 
-        with pytest.raises(PermissionError):
+        with pytest.raises(ValueError):
             await service.delete(comment_id=comment_id, user_id=other_user.id)
 
         # Verify comment still exists

--- a/tests/unit/webapp/test_shootout_comment_service.py
+++ b/tests/unit/webapp/test_shootout_comment_service.py
@@ -220,7 +220,7 @@ class TestShootoutCommentServiceListByShootout:
         session.add_all([comment1, comment2])
         await session.commit()
 
-        comments = await service.list_by_shootout(shootout.id)
+        comments = await service.list_by_shootout(shootout.id, user.id)
 
         assert len(comments) == 2
 
@@ -246,7 +246,7 @@ class TestShootoutCommentServiceListByShootout:
         session.add_all([comment1, comment2])
         await session.commit()
 
-        comments = await service.list_by_shootout(shootout.id)
+        comments = await service.list_by_shootout(shootout.id, user.id)
 
         assert comments[0].content == "Newer"
         assert comments[1].content == "Older"
@@ -255,10 +255,36 @@ class TestShootoutCommentServiceListByShootout:
     async def test_list_by_shootout_raises_for_nonexistent_shootout(
         self,
         service: ShootoutCommentService,
+        user: User,
     ) -> None:
         """Service.list_by_shootout raises ValueError when shootout doesn't exist."""
         with pytest.raises(ValueError, match="[Ss]hootout"):
-            await service.list_by_shootout(uuid4())
+            await service.list_by_shootout(uuid4(), user.id)
+
+    @pytest.mark.asyncio
+    async def test_list_by_shootout_raises_when_user_is_not_owner(
+        self,
+        service: ShootoutCommentService,
+        session: AsyncSession,
+        user: User,
+        other_user: User,
+        shootout: Shootout,
+    ) -> None:
+        """Service.list_by_shootout raises ValueError when user_id is not the
+        shootout owner - ownership enforced at query level, not by caller filtering."""
+        # A comment exists on `shootout` (owned by `user`).
+        session.add(
+            ShootoutComment(
+                shootout_id=shootout.id,
+                user_id=user.id,
+                content="owner-only",
+            )
+        )
+        await session.commit()
+
+        # other_user does not own the shootout -> ValueError (404 at the API).
+        with pytest.raises(ValueError, match="[Ss]hootout"):
+            await service.list_by_shootout(shootout.id, other_user.id)
 
 
 class TestShootoutCommentServiceDelete:

--- a/tests/unit/webapp/test_signal_chain_service.py
+++ b/tests/unit/webapp/test_signal_chain_service.py
@@ -129,7 +129,7 @@ class TestSignalChainServiceCreate:
         session.expire_all()
 
         # Assert - verify persisted by re-querying
-        result = await service.get_by_id(created.id)
+        result = await service.get_by_id(created.id, created.user_id)
         assert result is not None
         assert result.id == created.id
 
@@ -162,7 +162,7 @@ class TestSignalChainServiceGetById:
         created = await service.create(chain)
 
         # Act
-        result = await service.get_by_id(created.id)
+        result = await service.get_by_id(created.id, created.user_id)
 
         # Assert
         assert result is not None
@@ -175,7 +175,7 @@ class TestSignalChainServiceGetById:
     ) -> None:
         """Test getting a nonexistent chain returns None."""
         # Act
-        result = await service.get_by_id(uuid4())
+        result = await service.get_by_id(uuid4(), uuid4())
 
         # Assert
         assert result is None
@@ -334,7 +334,7 @@ class TestSignalChainServiceDelete:
         await service.delete(created.id)
 
         # Assert - chain should be gone
-        result = await service.get_by_id(created.id)
+        result = await service.get_by_id(created.id, created.user_id)
         assert result is None
 
     async def test_delete_nonexistent_chain_does_not_raise(


### PR DESCRIPTION
Closes #151.

Repositories enforce owner scoping in SQL rather than relying on callers to post-filter in Python. Every `get_by_id` (DI track, signal chain, signal-chain group, shootout, job, shootout comment) now takes `user_id` and constrains the WHERE clause; non-owner access returns not-found (no existence leak) instead of a permission error. `list_by_shootout` joins Shootout and filters `Shootout.user_id` in SQL. Service callers pass `current_user.id`.

Verification:
- Codex adversarial review: PASS (no findings).
- 23 repository ownership integration tests pass against a real Postgres, including cross-user rejection invariants (`test_ownership_enforcement.py`).
- mypy model/gts --strict clean (ports changed).
- Unit tests run in CI.