### PR TITLE
ci(app): gate frontend/app typecheck and build in CI and the worktree gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,28 @@ jobs:
       - run: pnpm build
 
       - run: pnpm check
+
+  app:
+    name: App SPA
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend/app
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "10"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: frontend/app/pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm typecheck
+
+      - run: pnpm build

--- a/scripts/worktree/gate.sh
+++ b/scripts/worktree/gate.sh
@@ -22,6 +22,12 @@ wt_dc exec -T webapp lint-imports
 wt_dc exec -T astro pnpm check
 wt_dc exec -T astro pnpm lint
 
+# --- App SPA checks (Vite + React under /app/*) ---
+# frontend/app carries no host port and is not on the provisioned stack, so run a
+# one-off container off the app image (its deps were installed with
+# --frozen-lockfile at build time). Typecheck (tsc --noEmit) then production build.
+wt_dc run --rm --no-deps -T app sh -c "pnpm typecheck && pnpm build"
+
 # --- Host-side checks (no container) ---
 # A fresh feature worktree has no model/video/node_modules (gitignored); install
 # the pinned deps once, then run the project-pinned tsc and eslint (not npx/global).


### PR DESCRIPTION
## Slice FE-app-gate-ci (frontend-reshape A4)

Add the Vite + React SPA at `frontend/app` to the automatic quality floor, so a broken type or build error fails in PR CI and the worktree gate before the SPA grows past the placeholder.

### Changes
- **`.github/workflows/ci.yml`** — new `app` job: installs `frontend/app` deps with the committed `pnpm-lock.yaml` and `--frozen-lockfile`, then runs `pnpm typecheck` and `pnpm build`. Mirrors the existing astro `frontend` job (pnpm 10, node 24, pnpm cache keyed on `frontend/app/pnpm-lock.yaml`).
- **`scripts/worktree/gate.sh`** — new app SPA check: a one-off `wt_dc run --rm --no-deps -T app sh -c "pnpm typecheck && pnpm build"`. The `app` service carries no host port and is not on the provisioned stack (provision starts only db/webapp/astro), so the check runs off the already-built `app` image, whose Dockerfile installs deps with `--frozen-lockfile`. `set -e` aborts the gate on failure.

### Scope
No UI feature work and no production nginx static cutover (that is the later A4 prod-static slice). `frontend/app/dist/` is gitignored, so the gate's build does not dirty the tree.

### Verification
- `just check` (worktree up + gate) passes end to end with the app check in place.
- Injecting a `tsc` type error makes the app gate command exit 2 and aborts the gate under `set -e`; reverted.
- Dependencies stay pinned through the committed lockfile; no unpinned global/npx execution.
- Codex adversarial review (gpt-5.5, high): PASS, no blocker findings.

Acceptance signal: PR CI and the worktree gate both fail on a broken `frontend/app` type or build error.