### PR TITLE
fix(security): block /api/admin/* at nginx (SEC-admin-gate)

### DIFF
--- a/infrastructure/nginx/nginx.conf.template
+++ b/infrastructure/nginx/nginx.conf.template
@@ -58,8 +58,10 @@ server {
         try_files /login.html /login/index.html =404;
     }
 
-    # Block all other admin routes externally (only accessible via direct backend port)
-    location /admin/ {
+    # Admin API is internal-only: reachable in-network at webapp:8000 (gts_admin,
+    # scheduled sweeps), never through the public proxy. This longest-prefix
+    # match beats the general /api/ proxy below; uniform 404, no existence leak.
+    location /api/admin/ {
         return 404;
     }
 

--- a/infrastructure/nginx/nginx.conf.template
+++ b/infrastructure/nginx/nginx.conf.template
@@ -59,8 +59,14 @@ server {
     }
 
     # Admin API is internal-only: reachable in-network at webapp:8000 (gts_admin,
-    # scheduled sweeps), never through the public proxy. This longest-prefix
-    # match beats the general /api/ proxy below; uniform 404, no existence leak.
+    # scheduled sweeps), never through the public proxy. The prefix block beats
+    # the general /api/ proxy below on longest-prefix match; the exact-match
+    # block covers the slashless /api/admin URI, which a prefix location with a
+    # trailing slash does not. Uniform 404, no existence leak.
+    location = /api/admin {
+        return 404;
+    }
+
     location /api/admin/ {
         return 404;
     }

--- a/tests/integration/infrastructure/test_nginx_admin_gate.py
+++ b/tests/integration/infrastructure/test_nginx_admin_gate.py
@@ -1,0 +1,48 @@
+"""The unauthenticated admin API must never be reachable through the public proxy.
+
+The admin router mounts at /api/admin/* and carries no authentication by design:
+access control is the network boundary. nginx must therefore 404 the prefix
+externally. A bare /admin/ block does not do this - nginx prefix matching sends
+/api/admin/* to the longer /api/ proxy match - so these tests pin the exact
+location that closes the hole.
+"""
+
+import re
+from pathlib import Path
+
+TEMPLATE = Path("/app/infrastructure/nginx/nginx.conf.template")
+
+
+def _location_blocks(content: str) -> dict[str, str]:
+    """Map location expression -> block body (flat parse; no nested locations)."""
+    blocks: dict[str, str] = {}
+    for match in re.finditer(r"location\s+([^\s{]+(?:\s+[^\s{]+)?)\s*\{([^}]*)\}", content):
+        blocks[match.group(1)] = match.group(2)
+    return blocks
+
+
+def test_api_admin_prefix_is_blocked() -> None:
+    blocks = _location_blocks(TEMPLATE.read_text())
+    assert "/api/admin/" in blocks, (
+        "nginx must define location /api/admin/ - a bare /admin/ block never "
+        "matches the real /api/admin/* router prefix"
+    )
+    body = blocks["/api/admin/"]
+    assert "return 404" in body, "the admin prefix must 404 externally"
+    assert "proxy_pass" not in body, "the admin prefix must never be proxied"
+
+
+def test_no_stale_admin_block() -> None:
+    """The old /admin/ block matched nothing the webapp serves; it must be gone."""
+    blocks = _location_blocks(TEMPLATE.read_text())
+    assert "/admin/" not in blocks, (
+        "stale location /admin/ found - the webapp has no /admin/* routes; "
+        "the real surface is /api/admin/*"
+    )
+
+
+def test_api_proxy_still_present() -> None:
+    """The general API proxy must survive the admin carve-out."""
+    blocks = _location_blocks(TEMPLATE.read_text())
+    assert "/api/" in blocks
+    assert "proxy_pass" in blocks["/api/"]

--- a/tests/integration/infrastructure/test_nginx_admin_gate.py
+++ b/tests/integration/infrastructure/test_nginx_admin_gate.py
@@ -32,6 +32,18 @@ def test_api_admin_prefix_is_blocked() -> None:
     assert "proxy_pass" not in body, "the admin prefix must never be proxied"
 
 
+def test_api_admin_exact_uri_is_blocked() -> None:
+    """A trailing-slash prefix location misses the slashless /api/admin URI."""
+    blocks = _location_blocks(TEMPLATE.read_text())
+    assert "= /api/admin" in blocks, (
+        "nginx must define location = /api/admin - the /api/admin/ prefix "
+        "block does not match the exact slashless URI"
+    )
+    body = blocks["= /api/admin"]
+    assert "return 404" in body
+    assert "proxy_pass" not in body
+
+
 def test_no_stale_admin_block() -> None:
     """The old /admin/ block matched nothing the webapp serves; it must be gone."""
     blocks = _location_blocks(TEMPLATE.read_text())


### PR DESCRIPTION
SEC-admin-gate from the 2026-07-06 dead-code/systems recon.

The admin router mounts at /api/admin/* with no authentication (network-boundary access control by design). nginx's existing block is location /admin/, which never matches - longest-prefix matching routes /api/admin/* through the general /api/ proxy - so the full admin surface (job list/detail, cancel, retry, enqueue, trigger-sync) was publicly reachable on production.

- Add location /api/admin/ returning uniform 404 (beats /api/ on longest-prefix); no proxy_pass, no existence leak.
- Delete the dead /admin/ block (the webapp has no /admin/* routes).
- Config tests pin the contract: admin prefix blocked and never proxied, stale block absent, general /api/ proxy intact.

In-network access via webapp:8000 (scripts/gts_admin.py, t3k_sync sweeps) is unaffected. Worktree gate green.