### PR TITLE
feat(jobs): single-writer transition service; closed terminal-set reconciliation

### DIFF
--- a/apps/webapp/src/webapp/services/job_dispatch.py
+++ b/apps/webapp/src/webapp/services/job_dispatch.py
@@ -99,7 +99,11 @@ async def enqueue_job(
         raise JobNotPendingError(job.status)
 
     queue, command = _route(job, source_bc)
-    await PgmqClient(session).send(queue, command)
+    pgmq = PgmqClient(session)
+    # The producer is self-sufficient: consumers create queues at startup, but
+    # an enqueue must not depend on a consumer ever having run (idempotent).
+    await pgmq.create_queue(queue)
+    await pgmq.send(queue, command)
     job.status = JobStatus.QUEUED
     if message is not None:
         job.message = message

--- a/apps/webapp/src/webapp/services/job_dispatch.py
+++ b/apps/webapp/src/webapp/services/job_dispatch.py
@@ -98,6 +98,25 @@ async def enqueue_job(
     if job.status != JobStatus.PENDING:
         raise JobNotPendingError(job.status)
 
+    await send_and_mark_queued(session, job, source_bc=source_bc, message=message)
+    await session.commit()
+    return job
+
+
+async def send_and_mark_queued(
+    session: AsyncSession,
+    job: Job,
+    *,
+    source_bc: str = "webapp",
+    message: str | None = None,
+) -> None:
+    """Outbox core: route, ensure the queue, send, flip to QUEUED. No commit.
+
+    For callers already inside a locked transaction (the reconcile projection);
+    the caller owns the commit that makes the send and the flip atomic with its
+    other writes. Everyone else uses enqueue_job, which locks, guards, and
+    commits.
+    """
     queue, command = _route(job, source_bc)
     pgmq = PgmqClient(session)
     # The producer is self-sufficient: consumers create queues at startup, but
@@ -107,5 +126,3 @@ async def enqueue_job(
     job.status = JobStatus.QUEUED
     if message is not None:
         job.message = message
-    await session.commit()
-    return job

--- a/apps/webapp/src/webapp/services/job_transitions.py
+++ b/apps/webapp/src/webapp/services/job_transitions.py
@@ -18,7 +18,7 @@ from sqlalchemy import select
 from gts.domain.value_objects.job_status import JobStatus, JobType
 from webapp.adapters.persistence.models.job import Job
 from webapp.adapters.persistence.models.shootout import Shootout, ShootoutStatus
-from webapp.services.job_dispatch import enqueue_job
+from webapp.services.job_dispatch import send_and_mark_queued
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -159,9 +159,13 @@ async def reconcile_parent(session: AsyncSession, parent_job_id: UUID) -> None:
         shootout.status = ShootoutStatus.PROCESSING
 
     if completed_children == total_children:
-        master_stmt = select(Job).where(
-            Job.parent_job_id == parent_job_id,
-            Job.job_type == JobType.SHOOTOUT_MASTER,
+        master_stmt = (
+            select(Job)
+            .where(
+                Job.parent_job_id == parent_job_id,
+                Job.job_type == JobType.SHOOTOUT_MASTER,
+            )
+            .with_for_update()
         )
         master_result = await session.execute(master_stmt)
         master_job = master_result.scalar_one_or_none()
@@ -176,7 +180,10 @@ async def reconcile_parent(session: AsyncSession, parent_job_id: UUID) -> None:
             )
             session.add(master_job)
             await session.flush()
-            # Enqueue through the outbox in the same transaction: the master
-            # job's creation, its QUEUED flip, and the pgmq send commit
-            # together with the reconcile that decided them.
-            await enqueue_job(session, master_job.id, message="Queued for master audio creation")
+        if master_job.status == JobStatus.PENDING:
+            # Outbox core, no commit: the master job's creation/recovery, its
+            # QUEUED flip, and the pgmq send stay in the reconcile transaction,
+            # committed by the transition service or the session wrapper.
+            await send_and_mark_queued(
+                session, master_job, message="Queued for master audio creation"
+            )

--- a/apps/webapp/src/webapp/services/job_transitions.py
+++ b/apps/webapp/src/webapp/services/job_transitions.py
@@ -1,0 +1,182 @@
+"""Single-writer job transition service (docs/design/job-system-contract.md).
+
+This module is the sole writer of Job.status and, via projection, of
+Shootout.status; a structural guard test pins the shrinking allowlist of
+not-yet-migrated legacy writers. Every move is validated against the
+transition table (JobStatus.can_transition_to); a terminal move on a
+SHOOTOUT_AUDIO child reconciles the parent shootout in the same transaction.
+Lock order, always: own job row -> parent job row -> shootout row.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+from gts.domain.value_objects.job_status import JobStatus, JobType
+from webapp.adapters.persistence.models.job import Job
+from webapp.adapters.persistence.models.shootout import Shootout, ShootoutStatus
+from webapp.services.job_dispatch import enqueue_job
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+#: Terminal states that project the parent shootout to FAILED. CANCELLED maps
+#: publicly to FAILED; the public lifecycle has five states, never more.
+FAILED_CLASS = frozenset({JobStatus.FAILED, JobStatus.CANCELLED, JobStatus.DEAD_LETTERED})
+
+
+class TransitionError(Exception):
+    """Base for transition failures."""
+
+
+class JobNotFoundForTransitionError(TransitionError):
+    """The job row does not exist."""
+
+
+class InvalidTransitionError(TransitionError):
+    """The requested move is not an edge of the transition table."""
+
+    def __init__(self, current: JobStatus, target: JobStatus) -> None:
+        self.current = current
+        self.target = target
+        super().__init__(f"Invalid transition {current.value} -> {target.value}")
+
+
+async def transition_job(
+    session: AsyncSession,
+    job_id: UUID,
+    to_status: JobStatus,
+    *,
+    error: str | None = None,
+    message: str | None = None,
+) -> Job:
+    """Move a job to `to_status`, reconcile its parent if terminal, and commit.
+
+    Locks the job row, validates the move against the transition table (an
+    invalid move raises before anything is written - a rejected no-op, never a
+    half-write), applies bookkeeping, and for a terminal SHOOTOUT_AUDIO child
+    re-projects the parent shootout inside the same transaction. The service
+    owns its commit; callers never commit around it.
+    """
+    stmt = select(Job).where(Job.id == job_id).with_for_update()
+    result = await session.execute(stmt)
+    job = result.scalar_one_or_none()
+    if job is None:
+        raise JobNotFoundForTransitionError(f"Job {job_id} not found")
+    if not job.status.can_transition_to(to_status):
+        raise InvalidTransitionError(job.status, to_status)
+
+    now = datetime.now(UTC)
+    job.status = to_status
+    if message is not None:
+        job.message = message
+    if error is not None:
+        job.error = error
+    if to_status == JobStatus.RUNNING:
+        if job.started_at is None:
+            job.started_at = now
+        job.last_heartbeat = now
+    if to_status.is_terminal():
+        job.completed_at = now
+
+    if (
+        to_status.is_terminal()
+        and job.job_type == JobType.SHOOTOUT_AUDIO
+        and job.parent_job_id is not None
+    ):
+        await reconcile_parent(session, job.parent_job_id)
+
+    await session.commit()
+    return job
+
+
+async def reconcile_parent(session: AsyncSession, parent_job_id: UUID) -> None:
+    """Project SHOOTOUT_AUDIO child states onto the parent job and shootout.
+
+    Counting is closed over the whole terminal set: every terminal child lands
+    in exactly one bucket (COMPLETED, or the FAILED_CLASS), so no terminal path
+    can strand the projection in PROCESSING. Runs inside the caller's
+    transaction and does not commit; the transition service (or the session
+    wrapper in shootout_reconciliation) owns the commit.
+    """
+    parent_stmt = select(Job).where(Job.id == parent_job_id).with_for_update()
+    parent_result = await session.execute(parent_stmt)
+    parent_job = parent_result.scalar_one_or_none()
+    if parent_job is None or parent_job.entity_id is None:
+        return
+
+    shootout_stmt = select(Shootout).where(Shootout.id == parent_job.entity_id).with_for_update()
+    shootout_result = await session.execute(shootout_stmt)
+    shootout = shootout_result.scalar_one_or_none()
+
+    child_stmt = select(Job).where(
+        Job.parent_job_id == parent_job_id,
+        Job.job_type == JobType.SHOOTOUT_AUDIO,
+    )
+    child_result = await session.execute(child_stmt)
+    audio_children = child_result.scalars().all()
+    if not audio_children:
+        return
+
+    total_children = len(audio_children)
+    completed_children = sum(1 for job in audio_children if job.status == JobStatus.COMPLETED)
+    failed_class_children = sum(1 for job in audio_children if job.status in FAILED_CLASS)
+
+    now = datetime.now(UTC)
+    parent_job.progress = int((completed_children / total_children) * 100)
+    parent_job.last_heartbeat = now
+
+    if failed_class_children > 0:
+        breakdown = ", ".join(
+            f"{count} {status.value}"
+            for status in (JobStatus.FAILED, JobStatus.CANCELLED, JobStatus.DEAD_LETTERED)
+            if (count := sum(1 for job in audio_children if job.status == status))
+        )
+        if parent_job.status.can_transition_to(JobStatus.FAILED):
+            parent_job.status = JobStatus.FAILED
+            parent_job.error = (
+                f"{failed_class_children} chain job(s) terminal without success: {breakdown}"
+            )
+            parent_job.completed_at = now
+        if shootout is not None and shootout.status != ShootoutStatus.COMPLETED:
+            shootout.status = ShootoutStatus.FAILED
+        return
+
+    if parent_job.status in {JobStatus.PENDING, JobStatus.QUEUED}:
+        parent_job.status = JobStatus.RUNNING
+        if parent_job.started_at is None:
+            parent_job.started_at = now
+
+    if shootout is not None and shootout.status not in {
+        ShootoutStatus.COMPLETED,
+        ShootoutStatus.FAILED,
+    }:
+        shootout.status = ShootoutStatus.PROCESSING
+
+    if completed_children == total_children:
+        master_stmt = select(Job).where(
+            Job.parent_job_id == parent_job_id,
+            Job.job_type == JobType.SHOOTOUT_MASTER,
+        )
+        master_result = await session.execute(master_stmt)
+        master_job = master_result.scalar_one_or_none()
+        if master_job is None:
+            master_job = Job(
+                user_id=parent_job.user_id,
+                job_type=JobType.SHOOTOUT_MASTER,
+                parent_job_id=parent_job.id,
+                entity_id=parent_job.entity_id,
+                status=JobStatus.PENDING,
+                progress=0,
+            )
+            session.add(master_job)
+            await session.flush()
+            # Enqueue through the outbox in the same transaction: the master
+            # job's creation, its QUEUED flip, and the pgmq send commit
+            # together with the reconcile that decided them.
+            await enqueue_job(session, master_job.id, message="Queued for master audio creation")

--- a/apps/webapp/src/webapp/services/shootout_reconciliation.py
+++ b/apps/webapp/src/webapp/services/shootout_reconciliation.py
@@ -1,113 +1,24 @@
-"""Shootout reconciliation logic shared between the audio worker and the shootout orchestrator."""
+"""Session-owning wrapper for parent reconciliation, shared by the workers.
+
+The projection logic lives in webapp.services.job_transitions (the single
+transition service); this wrapper exists for callers that hold no session -
+the audio worker and the shootout orchestrator - and preserves their
+call shape: reconcile_parent_after_audio(parent_job_id, database_url).
+"""
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
-from uuid import UUID
+from typing import TYPE_CHECKING
 
-from sqlalchemy import select
-
-from gts.domain.value_objects.job_status import JobStatus, JobType
-from messaging.commands import ProcessAudioCommand
 from messaging.db import get_session_no_tx as get_session
-from messaging.pgmq_client import PgmqClient
-from webapp.adapters.persistence.models.job import Job
-from webapp.adapters.persistence.models.shootout import Shootout, ShootoutStatus
+from webapp.services.job_transitions import reconcile_parent
 
-
-async def _dispatch_master_job(master_job_id: UUID, database_url: str) -> None:
-    """Dispatch a pending SHOOTOUT_MASTER job via pgmq audio_commands."""
-    async with get_session(database_url) as session:
-        stmt = select(Job).where(Job.id == master_job_id).with_for_update()
-        result = await session.execute(stmt)
-        master_job = result.scalar_one_or_none()
-        if master_job is None or master_job.status != JobStatus.PENDING:
-            return
-
-        pgmq = PgmqClient(session)
-        cmd = ProcessAudioCommand(
-            source_bc="audio-worker",
-            payload={
-                "job_id": str(master_job.id),
-                "shootout_id": str(master_job.entity_id),
-                "user_id": str(master_job.user_id),
-            },
-        )
-        await pgmq.send("audio_commands", cmd)
-        master_job.status = JobStatus.QUEUED
-        master_job.message = "Queued for master audio creation"
-        await session.commit()
+if TYPE_CHECKING:
+    from uuid import UUID
 
 
 async def reconcile_parent_after_audio(parent_job_id: UUID, database_url: str) -> None:
     """Reconcile parent SHOOTOUT state from child SHOOTOUT_AUDIO results."""
-    master_job_id: UUID | None = None
-
     async with get_session(database_url) as session:
-        parent_stmt = select(Job).where(Job.id == parent_job_id).with_for_update()
-        parent_result = await session.execute(parent_stmt)
-        parent_job = parent_result.scalar_one_or_none()
-        if parent_job is None or parent_job.entity_id is None:
-            return
-
-        shootout_stmt = select(Shootout).where(Shootout.id == parent_job.entity_id)
-        shootout_result = await session.execute(shootout_stmt)
-        shootout = shootout_result.scalar_one_or_none()
-
-        child_stmt = select(Job).where(
-            Job.parent_job_id == parent_job_id,
-            Job.job_type == JobType.SHOOTOUT_AUDIO,
-        )
-        child_result = await session.execute(child_stmt)
-        audio_children = child_result.scalars().all()
-        if not audio_children:
-            return
-
-        total_children = len(audio_children)
-        completed_children = sum(1 for job in audio_children if job.status == JobStatus.COMPLETED)
-        failed_children = sum(1 for job in audio_children if job.status == JobStatus.FAILED)
-
-        parent_job.progress = int((completed_children / total_children) * 100)
-        parent_job.last_heartbeat = datetime.now(UTC)
-
-        if failed_children > 0:
-            parent_job.status = JobStatus.FAILED
-            parent_job.error = f"{failed_children} chain job(s) failed"
-            parent_job.completed_at = datetime.now(UTC)
-            if shootout is not None:
-                shootout.status = ShootoutStatus.FAILED
-            await session.commit()
-            return
-
-        if parent_job.status in {JobStatus.PENDING, JobStatus.QUEUED}:
-            parent_job.status = JobStatus.RUNNING
-            if parent_job.started_at is None:
-                parent_job.started_at = datetime.now(UTC)
-
-        if shootout is not None:
-            shootout.status = ShootoutStatus.PROCESSING
-
-        if completed_children == total_children:
-            master_stmt = select(Job).where(
-                Job.parent_job_id == parent_job_id,
-                Job.job_type == JobType.SHOOTOUT_MASTER,
-            )
-            master_result = await session.execute(master_stmt)
-            master_job = master_result.scalar_one_or_none()
-            if master_job is None:
-                master_job = Job(
-                    user_id=parent_job.user_id,
-                    job_type=JobType.SHOOTOUT_MASTER,
-                    parent_job_id=parent_job.id,
-                    entity_id=parent_job.entity_id,
-                    status=JobStatus.PENDING,
-                    progress=0,
-                )
-                session.add(master_job)
-                await session.flush()
-            master_job_id = master_job.id
-
+        await reconcile_parent(session, parent_job_id)
         await session.commit()
-
-    if master_job_id is not None:
-        await _dispatch_master_job(master_job_id, database_url)

--- a/tests/integration/audio/test_process_audio_job.py
+++ b/tests/integration/audio/test_process_audio_job.py
@@ -604,7 +604,7 @@ async def test_reconcile_creates_master_after_all_complete(
     master_result = await db_session.execute(master_stmt)
     master_job = master_result.scalar_one_or_none()
     assert master_job is not None
-    assert master_job.status in {JobStatus.PENDING, JobStatus.QUEUED}
+    assert master_job.status == JobStatus.QUEUED
     assert master_job.entity_id == shootout_id
 
     # Verify parent progress = 100%

--- a/tests/integration/webapp/test_terminal_closure.py
+++ b/tests/integration/webapp/test_terminal_closure.py
@@ -1,0 +1,222 @@
+"""Reconciliation terminal closure and the transition service (ADR-0005).
+
+The adversarial shapes here are the pre-fix strand class: a CANCELLED or
+DEAD_LETTERED child under a PROCESSING parent used to land in neither the
+all-complete nor the any-failed branch, stranding the shootout in PROCESSING
+forever. Closed counting makes every terminal child land in exactly one bucket.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select, text
+
+from gts.domain.value_objects.job_status import JobStatus, JobType
+from messaging.pgmq_client import PgmqClient
+from webapp.adapters.persistence.models.job import Job
+from webapp.adapters.persistence.models.shootout import Shootout, ShootoutStatus
+from webapp.adapters.persistence.models.user import User
+from webapp.services.job_transitions import (
+    InvalidTransitionError,
+    reconcile_parent,
+    transition_job,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.fixture(autouse=True)
+async def _queues(db_session: AsyncSession) -> None:
+    """Reconcile enqueues the master job through the real outbox."""
+    await PgmqClient(db_session).create_queue("audio_commands")
+
+
+@pytest.fixture
+async def shootout_tree(db_session: AsyncSession, test_user: User) -> dict:
+    """A PROCESSING shootout with a RUNNING parent job and three audio children."""
+    shootout = Shootout(
+        id=uuid4(),
+        user_id=test_user.id,
+        name="Closure Shootout",
+        status=ShootoutStatus.PROCESSING,
+    )
+    db_session.add(shootout)
+
+    parent = Job(
+        id=uuid4(),
+        user_id=test_user.id,
+        job_type=JobType.SHOOTOUT,
+        entity_id=shootout.id,
+        status=JobStatus.RUNNING,
+        progress=0,
+    )
+    db_session.add(parent)
+
+    children = []
+    for _ in range(3):
+        child = Job(
+            id=uuid4(),
+            user_id=test_user.id,
+            job_type=JobType.SHOOTOUT_AUDIO,
+            parent_job_id=parent.id,
+            entity_id=uuid4(),
+            status=JobStatus.RUNNING,
+            progress=0,
+        )
+        db_session.add(child)
+        children.append(child)
+
+    await db_session.flush()
+    return {"shootout": shootout, "parent": parent, "children": children}
+
+
+async def _set_status(db_session: AsyncSession, job: Job, status: JobStatus) -> None:
+    """Test scaffolding: place a child in a precondition state directly."""
+    await db_session.execute(
+        text("UPDATE core_jobs SET status = :status WHERE id = :id"),
+        {"status": status.value, "id": str(job.id)},
+    )
+    db_session.expire(job)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestClosedReconciliation:
+    @pytest.mark.parametrize(
+        "stranding_status",
+        [JobStatus.CANCELLED, JobStatus.DEAD_LETTERED, JobStatus.FAILED],
+    )
+    async def test_any_failed_class_child_projects_shootout_failed(
+        self,
+        db_session: AsyncSession,
+        shootout_tree: dict,
+        stranding_status: JobStatus,
+    ) -> None:
+        """The strand class: one terminal-without-success child fails the run."""
+        parent = shootout_tree["parent"]
+        children = shootout_tree["children"]
+        await _set_status(db_session, children[0], JobStatus.COMPLETED)
+        await _set_status(db_session, children[1], JobStatus.COMPLETED)
+        await _set_status(db_session, children[2], stranding_status)
+
+        await reconcile_parent(db_session, parent.id)
+        await db_session.commit()
+
+        await db_session.refresh(parent)
+        await db_session.refresh(shootout_tree["shootout"])
+        assert parent.status == JobStatus.FAILED
+        assert shootout_tree["shootout"].status == ShootoutStatus.FAILED
+        assert stranding_status.value in (parent.error or "")
+
+    async def test_all_completed_spawns_and_enqueues_master(
+        self,
+        db_session: AsyncSession,
+        shootout_tree: dict,
+    ) -> None:
+        parent = shootout_tree["parent"]
+        for child in shootout_tree["children"]:
+            await _set_status(db_session, child, JobStatus.COMPLETED)
+
+        await reconcile_parent(db_session, parent.id)
+        await db_session.commit()
+
+        master = (
+            await db_session.execute(
+                select(Job).where(
+                    Job.parent_job_id == parent.id,
+                    Job.job_type == JobType.SHOOTOUT_MASTER,
+                )
+            )
+        ).scalar_one()
+        assert master.status == JobStatus.QUEUED
+
+        result = await db_session.execute(
+            text(
+                "SELECT message FROM pgmq.q_audio_commands "
+                "WHERE message->'payload'->>'job_id' = :jid"
+            ),
+            {"jid": str(master.id)},
+        )
+        assert len(result.fetchall()) == 1
+
+    async def test_incomplete_children_keep_processing(
+        self,
+        db_session: AsyncSession,
+        shootout_tree: dict,
+    ) -> None:
+        """No terminal-failure child and unfinished work: still PROCESSING."""
+        parent = shootout_tree["parent"]
+        await _set_status(db_session, shootout_tree["children"][0], JobStatus.COMPLETED)
+
+        await reconcile_parent(db_session, parent.id)
+        await db_session.commit()
+
+        await db_session.refresh(parent)
+        await db_session.refresh(shootout_tree["shootout"])
+        assert parent.status == JobStatus.RUNNING
+        assert shootout_tree["shootout"].status == ShootoutStatus.PROCESSING
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestTransitionService:
+    async def test_terminal_child_transition_reconciles_parent(
+        self,
+        db_session: AsyncSession,
+        shootout_tree: dict,
+    ) -> None:
+        """One call moves the child and re-projects the parent atomically."""
+        parent = shootout_tree["parent"]
+        children = shootout_tree["children"]
+        await _set_status(db_session, children[0], JobStatus.COMPLETED)
+        await _set_status(db_session, children[1], JobStatus.COMPLETED)
+
+        await transition_job(db_session, children[2].id, JobStatus.FAILED, error="render exploded")
+
+        await db_session.refresh(parent)
+        await db_session.refresh(shootout_tree["shootout"])
+        assert parent.status == JobStatus.FAILED
+        assert shootout_tree["shootout"].status == ShootoutStatus.FAILED
+
+        await db_session.refresh(children[2])
+        assert children[2].status == JobStatus.FAILED
+        assert children[2].error == "render exploded"
+        assert children[2].completed_at is not None
+
+    async def test_invalid_transition_is_rejected_without_writes(
+        self,
+        db_session: AsyncSession,
+        shootout_tree: dict,
+    ) -> None:
+        child = shootout_tree["children"][0]
+        await _set_status(db_session, child, JobStatus.COMPLETED)
+
+        with pytest.raises(InvalidTransitionError):
+            await transition_job(db_session, child.id, JobStatus.RUNNING)
+
+        await db_session.refresh(child)
+        assert child.status == JobStatus.COMPLETED
+
+    async def test_published_shootout_never_regresses(
+        self,
+        db_session: AsyncSession,
+        shootout_tree: dict,
+    ) -> None:
+        """Terminal-per-generation: a COMPLETED shootout stays COMPLETED."""
+        shootout = shootout_tree["shootout"]
+        await db_session.execute(
+            text("UPDATE core_shootouts SET status = :status WHERE id = :id"),
+            {"status": ShootoutStatus.COMPLETED.value, "id": str(shootout.id)},
+        )
+        db_session.expire(shootout)
+        await _set_status(db_session, shootout_tree["children"][0], JobStatus.DEAD_LETTERED)
+
+        await reconcile_parent(db_session, shootout_tree["parent"].id)
+        await db_session.commit()
+
+        await db_session.refresh(shootout)
+        assert shootout.status == ShootoutStatus.COMPLETED

--- a/tests/unit/webapp/test_status_writer_guard.py
+++ b/tests/unit/webapp/test_status_writer_guard.py
@@ -1,0 +1,84 @@
+"""Structural guard: only the transition service writes Job.status/Shootout.status.
+
+docs/design/job-system-contract.md makes webapp.services.job_transitions the
+sole writer of both status fields (with webapp.services.job_dispatch owning
+exactly the PENDING -> QUEUED outbox edge). Everything else in the allowlist
+below is a legacy writer awaiting migration by its named backlog unit; this
+test is a ratchet - adding a NEW direct status write anywhere fails it, and
+migrating a legacy writer requires shrinking the list, never growing it.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from pathlib import Path
+
+REPO = Path("/app")
+
+# ORM assignments to a .status attribute: enum literals plus the transition
+# service's dynamic target write (job.status = to_status).
+ORM_WRITE = re.compile(r"\.status\s*=\s*(?:(?:JobStatus|ShootoutStatus)\.|to_status\b)")
+# Raw-SQL writes that bypass the ORM entirely.
+RAW_WRITE = re.compile(r"UPDATE\s+(?:core_jobs|core_shootouts)\s+SET\s+status", re.IGNORECASE)
+
+# file (repo-relative) -> exact number of status writes sanctioned there.
+ALLOWED: dict[str, int] = {
+    # The transition service itself: transition_job + reconcile_parent projection.
+    "apps/webapp/src/webapp/services/job_transitions.py": 5,
+    # The outbox: exactly the PENDING -> QUEUED enqueue edge.
+    "apps/webapp/src/webapp/services/job_dispatch.py": 1,
+    # The run-request edge: shootout DRAFT -> PENDING at the process trigger.
+    "apps/webapp/src/webapp/api/v1/shootouts.py": 1,
+    # --- Legacy writers, shrink only ---
+    # DOM-terminal-writer-routing: admin cancel + admin retry.
+    "apps/webapp/src/webapp/api/admin.py": 2,
+    # DOM-terminal-writer-routing: user retry.
+    "apps/webapp/src/webapp/api/v1/jobs.py": 1,
+    # JOB-idempotent-consume + DOM-shootout-finalise: claim, complete, fail,
+    # and the master path's rogue parent/shootout projection.
+    "apps/audio_worker/src/audio_worker/consumer.py": 8,
+    # JOB-idempotent-consume: orchestrator claim + fan-out dispatch flips.
+    "apps/shootout_orchestrator/src/shootout_orchestrator/consumer.py": 3,
+    # DOM-reaper-render-race + DOM-terminal-writer-routing: raw-SQL reaper and
+    # retry sweep writes.
+    "apps/t3k_sync/src/t3k_sync/tasks.py": 3,
+}
+
+SCAN_ROOTS = ("apps", "model", "infra", "sources")
+
+
+def _count_status_writes() -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for root in SCAN_ROOTS:
+        for path in sorted((REPO / root).rglob("*.py")):
+            if "/tests/" in str(path):
+                continue
+            text = path.read_text(encoding="utf-8")
+            hits = len(ORM_WRITE.findall(text)) + len(RAW_WRITE.findall(text))
+            if hits:
+                counts[str(path.relative_to(REPO))] = hits
+    return counts
+
+
+def test_status_writers_match_allowlist_exactly() -> None:
+    actual = _count_status_writes()
+
+    unexpected = {f: c for f, c in actual.items() if f not in ALLOWED}
+    assert not unexpected, (
+        "New direct Job.status/Shootout.status writer(s) found - route them "
+        f"through webapp.services.job_transitions instead: {unexpected}"
+    )
+
+    grown = {f: (c, ALLOWED[f]) for f, c in actual.items() if c > ALLOWED[f]}
+    assert not grown, (
+        "Legacy status writer(s) grew - the allowlist is a ratchet; add no new "
+        f"direct writes (actual vs allowed): {grown}"
+    )
+
+    stale = {f: (actual.get(f, 0), c) for f, c in ALLOWED.items() if actual.get(f, 0) != c}
+    assert not stale, (
+        "Status-writer allowlist is stale - a migration shrank (or a refactor "
+        "moved) sanctioned writes; update ALLOWED to the new exact counts "
+        f"(actual vs allowed): {stale}"
+    )

--- a/tests/unit/webapp/test_status_writer_guard.py
+++ b/tests/unit/webapp/test_status_writer_guard.py
@@ -16,9 +16,10 @@ from pathlib import Path
 
 REPO = Path("/app")
 
-# ORM assignments to a .status attribute: enum literals plus the transition
-# service's dynamic target write (job.status = to_status).
-ORM_WRITE = re.compile(r"\.status\s*=\s*(?:(?:JobStatus|ShootoutStatus)\.|to_status\b)")
+# Any assignment to a .status attribute (enum literal or dynamic), excluding
+# comparisons and the gts domain entities' own self.status transitions (the
+# domain state machine is not an ORM write path).
+ORM_WRITE = re.compile(r"(?<!self)\.status\s*=(?!=)")
 # Raw-SQL writes that bypass the ORM entirely.
 RAW_WRITE = re.compile(r"UPDATE\s+(?:core_jobs|core_shootouts)\s+SET\s+status", re.IGNORECASE)
 
@@ -43,6 +44,12 @@ ALLOWED: dict[str, int] = {
     # DOM-reaper-render-race + DOM-terminal-writer-routing: raw-SQL reaper and
     # retry sweep writes.
     "apps/t3k_sync/src/t3k_sync/tasks.py": 3,
+    # DOM-terminal-writer-routing: the SOURCE_SYNC lifecycle writer.
+    "apps/t3k_sync/src/t3k_sync/source_sync.py": 1,
+    # Domain->ORM mapping in the shootout repository save path.
+    "apps/webapp/src/webapp/adapters/persistence/repositories/shootout_repository.py": 1,
+    # DEBT-backend-dead-modules: the unused job repository write path.
+    "apps/webapp/src/webapp/adapters/persistence/repositories/job_repository.py": 1,
 }
 
 SCAN_ROOTS = ("apps", "model", "infra", "sources")


### PR DESCRIPTION
DOM-reconcile-terminal-closure from the job-reliability cluster (design authority: docs/design/job-system-contract.md; decision: ADR-0005).

- New webapp/services/job_transitions.py: transition_job (row lock, transition-table validation, bookkeeping, same-transaction parent reconcile, service-owned commit) and reconcile_parent with counting closed over the whole terminal set - a CANCELLED/DEAD_LETTERED child now projects the parent job and shootout to FAILED instead of stranding PROCESSING.
- Master-job dispatch moves inside the reconcile transaction through the outbox (enqueue_job); _dispatch_master_job deleted. enqueue_job now creates its target queue idempotently so producers never depend on a consumer having started.
- shootout_reconciliation.py becomes a thin session-owning wrapper; worker call shape unchanged.
- Terminal-per-generation: a COMPLETED shootout never regresses.
- Structural guard test: exact shrink-only allowlist of every Job.status/Shootout.status writer (ORM and raw SQL), so new direct writers fail the build and follow-up units must shrink the list as they migrate writers.
- Adversarial closure tests parametrised over FAILED/CANCELLED/DEAD_LETTERED.

Gate: full worktree gate green (804 unit tests + integration).