### PR TITLE
fix(tests): status-writer guard repo root works on bare CI runners

### DIFF
--- a/tests/unit/webapp/test_status_writer_guard.py
+++ b/tests/unit/webapp/test_status_writer_guard.py
@@ -14,7 +14,9 @@ import re
 from collections import Counter
 from pathlib import Path
 
-REPO = Path("/app")
+# Repo root resolved relative to this file: /app in the compose container,
+# the checkout root on a bare CI runner. Never hardcode the container mount.
+REPO = Path(__file__).resolve().parents[3]
 
 # Any assignment to a .status attribute (enum literal or dynamic), excluding
 # comparisons and the gts domain entities' own self.status transitions (the


### PR DESCRIPTION
The guard test hardcoded the compose container mount /app, so on the GitHub runner it scanned nothing and failed with all-zero counts (PR #193 was merged on a partial checks read - the container gate masked the path assumption). Resolve the repo root relative to the test file instead; verified green both in-container and via the host checkout path.