### PR TITLE
feat(jobs): route every terminal writer through the transition service; bounded auto-retry

### DIFF
--- a/apps/audio_worker/src/audio_worker/consumer.py
+++ b/apps/audio_worker/src/audio_worker/consumer.py
@@ -37,6 +37,7 @@ from webapp.adapters.persistence.models.shootout import (
 )
 from webapp.adapters.persistence.models.signal_chain import SignalChain
 from webapp.adapters.persistence.models.user_gear import UserGear
+from webapp.services.job_transitions import mark_job_dead_lettered
 from webapp.services.shootout_reconciliation import reconcile_parent_after_audio
 
 logger = logging.getLogger(__name__)
@@ -386,6 +387,10 @@ class ProcessAudioConsumer(BaseConsumer):
         command = ProcessAudioCommand.model_validate(envelope.model_dump(mode="python"))
         job_id = UUID(command.payload["job_id"])
         await process_audio_job(job_id)
+
+    async def on_dead_letter(self, message: dict[str, object], reason: str) -> None:
+        """Couple the job row to the queue-level DLQ in the same commit."""
+        await mark_job_dead_lettered(self._session, message, reason)
 
     async def commit_message(self) -> None:
         """Commit domain writes and queue archive in one transaction."""

--- a/apps/shootout_orchestrator/src/shootout_orchestrator/consumer.py
+++ b/apps/shootout_orchestrator/src/shootout_orchestrator/consumer.py
@@ -17,6 +17,7 @@ from messaging.db import get_session_no_tx as get_session
 from messaging.pgmq_client import PgmqClient
 from webapp.adapters.persistence.models.job import Job
 from webapp.adapters.persistence.models.shootout import Shootout, ShootoutStatus
+from webapp.services.job_transitions import mark_job_dead_lettered
 from webapp.services.shootout_reconciliation import reconcile_parent_after_audio
 
 if TYPE_CHECKING:
@@ -133,6 +134,10 @@ class StartShootoutConsumer(BaseConsumer):
         command = StartShootoutCommand.model_validate(envelope.model_dump(mode="python"))
         job_id = UUID(command.payload["job_id"])
         await process_shootout_job(job_id)
+
+    async def on_dead_letter(self, message: dict[str, object], reason: str) -> None:
+        """Couple the job row to the queue-level DLQ in the same commit."""
+        await mark_job_dead_lettered(self._session, message, reason)
 
     async def commit_message(self) -> None:
         """Commit queue archive in the session used by the pgmq client."""

--- a/apps/t3k_sync/src/t3k_sync/source_sync.py
+++ b/apps/t3k_sync/src/t3k_sync/source_sync.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
-from sqlalchemy import select, text
+from sqlalchemy import text
 
 from gts.domain.auth_gate import check_auth_status
 from gts.domain.value_objects.job_status import JobStatus, JobType
@@ -90,22 +89,32 @@ async def _create_source_sync_job() -> UUID:
             status=JobStatus.PENDING,
             progress=0,
             attempt=1,
-            max_attempts=3,
+            max_attempts=2,
         )
         session.add(job)
         await session.flush()
         return job.id
 
 
-async def _update_job_status(job_id: UUID, status: JobStatus, **fields: object) -> None:
-    """Update job status in gts_core."""
-    async with get_core_session() as session:
-        result = await session.execute(select(Job).where(Job.id == job_id))
-        job = result.scalar_one_or_none()
-        if job is not None:
-            job.status = status
-            for key, value in fields.items():
-                setattr(job, key, value)
+async def _update_job_status(
+    job_id: UUID,
+    status: JobStatus,
+    *,
+    message: str | None = None,
+    error: str | None = None,
+) -> None:
+    """Route the SOURCE_SYNC job lifecycle through the transition service.
+
+    Timestamps (started_at, last_heartbeat, completed_at) are the service's
+    bookkeeping; RUNNING -> RUNNING renewals are the lease heartbeat.
+    """
+    from webapp.services.job_transitions import TransitionError, transition_job
+
+    async with get_core_session_no_tx() as session:
+        try:
+            await transition_job(session, job_id, status, message=message, error=error)
+        except TransitionError as exc:
+            logger.warning("Sync job %s transition rejected: %s", job_id, exc)
 
 
 async def run_source_sync(
@@ -120,12 +129,7 @@ async def run_source_sync(
     try:
         _check_auth_gate()
     except RuntimeError as error:
-        await _update_job_status(
-            tracked_job_id,
-            JobStatus.FAILED,
-            error=str(error),
-            completed_at=datetime.now(UTC),
-        )
+        await _update_job_status(tracked_job_id, JobStatus.FAILED, error=str(error))
         raise
 
     _owns_tm = token_manager is None
@@ -137,18 +141,16 @@ async def run_source_sync(
         acquired = result.scalar()
         if not acquired:
             logger.info("Sync lock already held, skipping run")
+            # A superseded run never did any work: CANCELLED, not COMPLETED
+            # (PENDING -> COMPLETED is not a transition-table edge).
             await _update_job_status(
                 tracked_job_id,
-                JobStatus.COMPLETED,
+                JobStatus.CANCELLED,
                 message="Superseded by an active sync run",
-                completed_at=datetime.now(UTC),
             )
             return tracked_job_id
 
-        now = datetime.now(UTC)
-        await _update_job_status(
-            tracked_job_id, JobStatus.RUNNING, started_at=now, last_heartbeat=now
-        )
+        await _update_job_status(tracked_job_id, JobStatus.RUNNING)
 
         try:
             async with get_core_session_no_tx() as session:
@@ -164,11 +166,8 @@ async def run_source_sync(
                 )
 
                 async def renew_lock() -> None:
-                    await _update_job_status(
-                        tracked_job_id,
-                        JobStatus.RUNNING,
-                        last_heartbeat=datetime.now(UTC),
-                    )
+                    # RUNNING -> RUNNING lease heartbeat renewal.
+                    await _update_job_status(tracked_job_id, JobStatus.RUNNING)
 
                 mode = _get_sync_mode()
                 result = await sync_service.run_sync_batch(
@@ -186,21 +185,12 @@ async def run_source_sync(
                     result.hit_known_tone,
                 )
 
-            await _update_job_status(
-                tracked_job_id,
-                JobStatus.COMPLETED,
-                completed_at=datetime.now(UTC),
-            )
+            await _update_job_status(tracked_job_id, JobStatus.COMPLETED)
             if tracker is not None:
                 tracker.record_sync_success()
         except Exception:
             logger.exception("Sync batch failed")
-            await _update_job_status(
-                tracked_job_id,
-                JobStatus.FAILED,
-                error="Sync batch failed",
-                completed_at=datetime.now(UTC),
-            )
+            await _update_job_status(tracked_job_id, JobStatus.FAILED, error="Sync batch failed")
             if tracker is not None:
                 tracker.record_sync_failure("Sync batch failed")
         finally:

--- a/apps/t3k_sync/src/t3k_sync/source_sync.py
+++ b/apps/t3k_sync/src/t3k_sync/source_sync.py
@@ -102,6 +102,7 @@ async def _update_job_status(
     *,
     message: str | None = None,
     error: str | None = None,
+    renewal: bool = False,
 ) -> None:
     """Route the SOURCE_SYNC job lifecycle through the transition service.
 
@@ -112,7 +113,9 @@ async def _update_job_status(
 
     async with get_core_session_no_tx() as session:
         try:
-            await transition_job(session, job_id, status, message=message, error=error)
+            await transition_job(
+                session, job_id, status, message=message, error=error, renewal=renewal
+            )
         except TransitionError as exc:
             logger.warning("Sync job %s transition rejected: %s", job_id, exc)
 
@@ -166,8 +169,8 @@ async def run_source_sync(
                 )
 
                 async def renew_lock() -> None:
-                    # RUNNING -> RUNNING lease heartbeat renewal.
-                    await _update_job_status(tracked_job_id, JobStatus.RUNNING)
+                    # RUNNING -> RUNNING lease heartbeat renewal by the holder.
+                    await _update_job_status(tracked_job_id, JobStatus.RUNNING, renewal=True)
 
                 mode = _get_sync_mode()
                 result = await sync_service.run_sync_batch(

--- a/apps/t3k_sync/src/t3k_sync/tasks.py
+++ b/apps/t3k_sync/src/t3k_sync/tasks.py
@@ -24,6 +24,7 @@ from webapp.services.job_dispatch import (
     JobNotPendingError,
     enqueue_job,
 )
+from webapp.services.job_transitions import TransitionError, transition_job
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -274,25 +275,49 @@ async def monitor_stale_jobs() -> None:
 
 
 async def process_pending_retries() -> None:
-    """Reset FAILED jobs whose retry time has passed back to PENDING."""
+    """Claim FAILED jobs whose retry time has passed and re-enqueue them.
+
+    Each claim routes FAILED -> PENDING through the transition service
+    (attempt bookkeeping, parent re-projection) and re-enqueues through the
+    outbox. next_retry_at is only ever set under the attempt cap (ADR-0005),
+    so the due-time predicate is the whole eligibility test.
+    """
     now = datetime.now(UTC)
     stmt = text("""
-        UPDATE core_jobs SET status = :pending_status
+        SELECT id FROM core_jobs
         WHERE status = :failed_status
           AND next_retry_at IS NOT NULL
           AND next_retry_at <= :now
           AND attempt < max_attempts
+        LIMIT 50
     """)
-    params = {
-        "pending_status": JobStatus.PENDING.value,
-        "failed_status": JobStatus.FAILED.value,
-        "now": now,
-    }
+    params = {"failed_status": JobStatus.FAILED.value, "now": now}
+
     if _test_session is not None:
-        await _test_session.execute(stmt, params)
-        return
-    async with get_core_session() as session:
-        await session.execute(stmt, params)
+        result = await _test_session.execute(stmt, params)
+        job_ids = [row[0] for row in result.fetchall()]
+    else:
+        async with get_core_session_no_tx() as session:
+            result = await session.execute(stmt, params)
+            job_ids = [row[0] for row in result.fetchall()]
+
+    for job_id in job_ids:
+        try:
+            if _test_session is not None:
+                await transition_job(
+                    _test_session, job_id, JobStatus.PENDING, message="Automatic retry"
+                )
+                await enqueue_job(_test_session, job_id, source_bc="t3k-sync")
+            else:
+                async with get_core_session_no_tx() as session:
+                    await transition_job(
+                        session, job_id, JobStatus.PENDING, message="Automatic retry"
+                    )
+                    await enqueue_job(session, job_id, source_bc="t3k-sync")
+        except (TransitionError, JobDispatchError) as exc:
+            logger.warning("Cannot auto-retry job %s: %s", job_id, exc)
+        except Exception:
+            logger.exception("Error auto-retrying job %s", job_id)
 
 
 async def dispatch_pending_jobs() -> None:

--- a/apps/webapp/src/webapp/adapters/persistence/models/job.py
+++ b/apps/webapp/src/webapp/adapters/persistence/models/job.py
@@ -98,7 +98,7 @@ class Job(UUIDMixin, TimestampMixin, Base):
 
     # Retry tracking
     attempt: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
-    max_attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+    max_attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=2)
     next_retry_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Result and error tracking

--- a/apps/webapp/src/webapp/api/admin.py
+++ b/apps/webapp/src/webapp/api/admin.py
@@ -6,6 +6,7 @@ No authentication required. Access is controlled at the network level
 
 from __future__ import annotations
 
+import contextlib
 import time
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
@@ -36,6 +37,11 @@ from webapp.services.job_dispatch import (
     JobNotPendingError,
     UnroutableJobTypeError,
     enqueue_job,
+)
+from webapp.services.job_transitions import (
+    InvalidTransitionError,
+    JobNotFoundForTransitionError,
+    transition_job,
 )
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
@@ -146,26 +152,16 @@ async def cancel_job(
     job_id: UUID,
     session: AsyncSession = Depends(_get_db),
 ) -> JobDetail:
-    """Cancel a job by setting its status to CANCELLED."""
-    result = await session.execute(select(Job).where(Job.id == job_id))
-    job = result.scalar_one_or_none()
-    if job is None:
+    """Cancel a job through the transition service (reconciles the parent)."""
+    try:
+        job = await transition_job(session, job_id, JobStatus.CANCELLED)
+    except JobNotFoundForTransitionError:
         raise HTTPException(status_code=404, detail="Job not found")
-
-    terminal_states = {
-        JobStatus.COMPLETED,
-        JobStatus.FAILED,
-        JobStatus.CANCELLED,
-        JobStatus.DEAD_LETTERED,
-    }
-    if job.status in terminal_states:
+    except InvalidTransitionError as exc:
         raise HTTPException(
             status_code=409,
-            detail=f"Cannot cancel job in {job.status.value} state",
+            detail=f"Cannot cancel job in {exc.current.value} state",
         )
-
-    job.status = JobStatus.CANCELLED
-    await session.commit()
     await session.refresh(job)
 
     children_result = await session.execute(select(Job).where(Job.parent_job_id == job_id))
@@ -181,30 +177,23 @@ async def retry_job(
     job_id: UUID,
     session: AsyncSession = Depends(_get_db),
 ) -> JobDetail:
-    """Retry a failed or dead-lettered job by resetting it to PENDING."""
-    result = await session.execute(select(Job).where(Job.id == job_id))
-    job = result.scalar_one_or_none()
-    if job is None:
+    """Retry a failed or dead-lettered job through the transition service."""
+    try:
+        job = await transition_job(session, job_id, JobStatus.PENDING)
+    except JobNotFoundForTransitionError:
         raise HTTPException(status_code=404, detail="Job not found")
-
-    retryable_states = {JobStatus.FAILED, JobStatus.DEAD_LETTERED}
-    if job.status not in retryable_states:
+    except InvalidTransitionError as exc:
         raise HTTPException(
             status_code=409,
-            detail=f"Cannot retry job in {job.status.value} state",
+            detail=f"Cannot retry job in {exc.current.value} state",
         )
 
-    job.status = JobStatus.PENDING
-    job.error = None
-    await session.flush()
-
-    # Enqueue atomically with the PENDING reset (transactional outbox).
-    # Self-managed types (SOURCE_SYNC) have no queue route and stay PENDING
-    # for their own scheduler; everything else must not wait on the sweep.
-    try:
+    # Re-enqueue through the outbox. Two service transactions (transition,
+    # then enqueue); a crash between them leaves a consistent PENDING job the
+    # dispatch sweep recovers. Self-managed types (SOURCE_SYNC) have no queue
+    # route and stay PENDING for their own scheduler.
+    with contextlib.suppress(UnroutableJobTypeError):
         await enqueue_job(session, job.id, message="Queued for retry")
-    except UnroutableJobTypeError:
-        await session.commit()
     await session.refresh(job)
 
     children_result = await session.execute(select(Job).where(Job.parent_job_id == job_id))
@@ -262,7 +251,7 @@ async def trigger_sync(
         status=JobStatus.PENDING,
         progress=0,
         attempt=1,
-        max_attempts=3,
+        max_attempts=2,
     )
     session.add(job)
     await session.commit()

--- a/apps/webapp/src/webapp/api/v1/jobs.py
+++ b/apps/webapp/src/webapp/api/v1/jobs.py
@@ -13,6 +13,7 @@ from webapp.adapters.persistence.models.user import User
 from webapp.api.v1.schemas.job import JobResponse
 from webapp.services.job_dispatch import enqueue_job
 from webapp.services.job_service import JobService
+from webapp.services.job_transitions import InvalidTransitionError, transition_job
 
 router = APIRouter(prefix="/api/jobs", tags=["jobs"])
 
@@ -204,13 +205,16 @@ async def retry_job(
             detail="Only failed jobs can be retried",
         )
 
-    # Transactional outbox: the PENDING reset and the pgmq send commit together
-    # inside enqueue_job.
-    job_model.status = JobStatus.PENDING
-    job_model.progress = 0
-    job_model.error = None
-    await db.flush()
-
+    # Route the retry claim through the transition service (attempt
+    # bookkeeping, parent re-projection), then re-enqueue through the outbox;
+    # a crash between the two leaves a PENDING job the dispatch sweep recovers.
+    try:
+        await transition_job(db, job_model.id, JobStatus.PENDING)
+    except InvalidTransitionError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Only failed jobs can be retried",
+        )
     await enqueue_job(db, job_model.id, message="Queued for retry")
     await db.refresh(job_model)
 

--- a/apps/webapp/src/webapp/services/job_dispatch.py
+++ b/apps/webapp/src/webapp/services/job_dispatch.py
@@ -30,6 +30,11 @@ _AUDIO_JOB_TYPES = frozenset(
 )
 
 
+def is_queue_routable(job_type: JobType) -> bool:
+    """Whether the type rides a pgmq queue (and so participates in auto-retry)."""
+    return job_type == JobType.SHOOTOUT or job_type in _AUDIO_JOB_TYPES
+
+
 class JobDispatchError(Exception):
     """Base for enqueue failures the caller maps to a response."""
 

--- a/apps/webapp/src/webapp/services/job_transitions.py
+++ b/apps/webapp/src/webapp/services/job_transitions.py
@@ -4,30 +4,39 @@ This module is the sole writer of Job.status and, via projection, of
 Shootout.status; a structural guard test pins the shrinking allowlist of
 not-yet-migrated legacy writers. Every move is validated against the
 transition table (JobStatus.can_transition_to); a terminal move on a
-SHOOTOUT_AUDIO child reconciles the parent shootout in the same transaction.
+SHOOTOUT_AUDIO child - and a retry claim back to PENDING - reconciles the
+parent shootout in the same transaction.
 Lock order, always: own job row -> parent job row -> shootout row.
 """
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+import logging
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 from sqlalchemy import select
 
 from gts.domain.value_objects.job_status import JobStatus, JobType
 from webapp.adapters.persistence.models.job import Job
 from webapp.adapters.persistence.models.shootout import Shootout, ShootoutStatus
-from webapp.services.job_dispatch import send_and_mark_queued
+from webapp.services.job_dispatch import is_queue_routable, send_and_mark_queued
 
 if TYPE_CHECKING:
-    from uuid import UUID
-
     from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
 
 #: Terminal states that project the parent shootout to FAILED. CANCELLED maps
 #: publicly to FAILED; the public lifecycle has five states, never more.
 FAILED_CLASS = frozenset({JobStatus.FAILED, JobStatus.CANCELLED, JobStatus.DEAD_LETTERED})
+
+#: Delay before the retry sweep picks up an automatically retryable failure.
+RETRY_BACKOFF = timedelta(seconds=120)
+
+#: Job states a retry claim (-> PENDING) can come from.
+_RETRY_SOURCES = frozenset({JobStatus.FAILED, JobStatus.DEAD_LETTERED})
 
 
 class TransitionError(Exception):
@@ -55,13 +64,13 @@ async def transition_job(
     error: str | None = None,
     message: str | None = None,
 ) -> Job:
-    """Move a job to `to_status`, reconcile its parent if terminal, and commit.
+    """Move a job to `to_status`, reconcile its parent if needed, and commit.
 
     Locks the job row, validates the move against the transition table (an
     invalid move raises before anything is written - a rejected no-op, never a
-    half-write), applies bookkeeping, and for a terminal SHOOTOUT_AUDIO child
-    re-projects the parent shootout inside the same transaction. The service
-    owns its commit; callers never commit around it.
+    half-write), applies bookkeeping, and for a SHOOTOUT_AUDIO child re-projects
+    the parent shootout inside the same transaction on terminal moves and on
+    retry claims. The service owns its commit; callers never commit around it.
     """
     stmt = select(Job).where(Job.id == job_id).with_for_update()
     result = await session.execute(stmt)
@@ -72,6 +81,7 @@ async def transition_job(
         raise InvalidTransitionError(job.status, to_status)
 
     now = datetime.now(UTC)
+    from_status = job.status
     job.status = to_status
     if message is not None:
         job.message = message
@@ -84,15 +94,82 @@ async def transition_job(
     if to_status.is_terminal():
         job.completed_at = now
 
+    # Retry bookkeeping (ADR-0005: bounded to max_attempts total, one automatic
+    # retry). A failure under the cap schedules the sweep pickup; at the cap it
+    # stays FAILED for admin action. Only queue-routable types auto-retry:
+    # self-managed types (SOURCE_SYNC) have their own scheduler and no route
+    # for the sweep to re-enqueue. A retry claim consumes an attempt and
+    # clears the failure state.
+    if to_status == JobStatus.FAILED:
+        job.next_retry_at = (
+            now + RETRY_BACKOFF
+            if job.attempt < job.max_attempts and is_queue_routable(job.job_type)
+            else None
+        )
+    if to_status == JobStatus.PENDING and from_status in _RETRY_SOURCES:
+        job.attempt += 1
+        job.error = None
+        job.next_retry_at = None
+        job.progress = 0
+        job.completed_at = None
+
     if (
-        to_status.is_terminal()
-        and job.job_type == JobType.SHOOTOUT_AUDIO
+        job.job_type == JobType.SHOOTOUT_AUDIO
         and job.parent_job_id is not None
+        and (
+            to_status.is_terminal()
+            or (to_status == JobStatus.PENDING and from_status in _RETRY_SOURCES)
+        )
     ):
         await reconcile_parent(session, job.parent_job_id)
 
+    # Parent cancel blocks completion only (ADR-0005): a terminal move on the
+    # parent SHOOTOUT job itself projects the shootout to FAILED unless it is
+    # already published; in-flight children finish but are never published.
+    if (
+        to_status.is_terminal()
+        and to_status != JobStatus.COMPLETED
+        and job.job_type == JobType.SHOOTOUT
+        and job.entity_id is not None
+    ):
+        shootout_stmt = select(Shootout).where(Shootout.id == job.entity_id).with_for_update()
+        shootout_result = await session.execute(shootout_stmt)
+        shootout = shootout_result.scalar_one_or_none()
+        if shootout is not None and shootout.status != ShootoutStatus.COMPLETED:
+            shootout.status = ShootoutStatus.FAILED
+
     await session.commit()
     return job
+
+
+async def mark_job_dead_lettered(
+    session: AsyncSession,
+    message: dict[str, object],
+    reason: str,
+) -> None:
+    """Couple a dead-lettered queue message to its job row, same transaction.
+
+    Parses the job id from the message payload and transitions the job to
+    DEAD_LETTERED in the caller's session, so the queue-level DLQ write and
+    the job-row state commit together and can never diverge. Messages without
+    a resolvable job row, and jobs already terminal, are logged and skipped -
+    the DLQ envelope remains the redrive source either way.
+    """
+    payload = message.get("payload") if isinstance(message, dict) else None
+    raw_job_id = payload.get("job_id") if isinstance(payload, dict) else None
+    if raw_job_id is None:
+        return
+    try:
+        job_id = UUID(str(raw_job_id))
+    except ValueError:
+        logger.warning("Dead-lettered message carries unparseable job_id %r", raw_job_id)
+        return
+    try:
+        await transition_job(
+            session, job_id, JobStatus.DEAD_LETTERED, error=f"dead-lettered: {reason}"
+        )
+    except TransitionError as exc:
+        logger.warning("Dead-letter job coupling skipped for %s: %s", job_id, exc)
 
 
 async def reconcile_parent(session: AsyncSession, parent_job_id: UUID) -> None:
@@ -147,15 +224,27 @@ async def reconcile_parent(session: AsyncSession, parent_job_id: UUID) -> None:
             shootout.status = ShootoutStatus.FAILED
         return
 
+    # Retry re-projection: a FAILED, unpublished run whose failed-class
+    # children have all been reclaimed comes back to life. Terminal per
+    # generation: a published (COMPLETED) shootout never re-enters.
+    if parent_job.status == JobStatus.FAILED:
+        parent_job.status = JobStatus.RUNNING
+        parent_job.error = None
+        parent_job.completed_at = None
+
     if parent_job.status in {JobStatus.PENDING, JobStatus.QUEUED}:
         parent_job.status = JobStatus.RUNNING
         if parent_job.started_at is None:
             parent_job.started_at = now
 
-    if shootout is not None and shootout.status not in {
-        ShootoutStatus.COMPLETED,
-        ShootoutStatus.FAILED,
-    }:
+    # A terminal parent (cancelled/dead-lettered) blocks completion: children
+    # finish but nothing is published and no master is spawned.
+    if parent_job.status.is_terminal():
+        return
+
+    # No failed-class child exists here, so a FAILED projection is stale by
+    # construction (a reclaimed prior failure) - revive it alongside the parent.
+    if shootout is not None and shootout.status != ShootoutStatus.COMPLETED:
         shootout.status = ShootoutStatus.PROCESSING
 
     if completed_children == total_children:

--- a/apps/webapp/src/webapp/services/job_transitions.py
+++ b/apps/webapp/src/webapp/services/job_transitions.py
@@ -35,6 +35,9 @@ FAILED_CLASS = frozenset({JobStatus.FAILED, JobStatus.CANCELLED, JobStatus.DEAD_
 #: Delay before the retry sweep picks up an automatically retryable failure.
 RETRY_BACKOFF = timedelta(seconds=120)
 
+#: A RUNNING job whose heartbeat is younger than this holds a live lease.
+LEASE_THRESHOLD = timedelta(seconds=120)
+
 #: Job states a retry claim (-> PENDING) can come from.
 _RETRY_SOURCES = frozenset({JobStatus.FAILED, JobStatus.DEAD_LETTERED})
 
@@ -56,6 +59,13 @@ class InvalidTransitionError(TransitionError):
         super().__init__(f"Invalid transition {current.value} -> {target.value}")
 
 
+class LiveLeaseError(TransitionError):
+    """A RUNNING re-claim was attempted while another consumer's lease is live."""
+
+    def __init__(self) -> None:
+        super().__init__("Job holds a live lease; re-claim requires a stale heartbeat")
+
+
 async def transition_job(
     session: AsyncSession,
     job_id: UUID,
@@ -63,6 +73,7 @@ async def transition_job(
     *,
     error: str | None = None,
     message: str | None = None,
+    renewal: bool = False,
 ) -> Job:
     """Move a job to `to_status`, reconcile its parent if needed, and commit.
 
@@ -71,6 +82,11 @@ async def transition_job(
     half-write), applies bookkeeping, and for a SHOOTOUT_AUDIO child re-projects
     the parent shootout inside the same transaction on terminal moves and on
     retry claims. The service owns its commit; callers never commit around it.
+
+    A RUNNING -> RUNNING move is either a lease heartbeat renewal by the
+    holder (`renewal=True`) or a re-claim after redelivery, which requires the
+    previous lease to be stale - a fresh heartbeat raises LiveLeaseError so a
+    duplicate consumer can never steal live work.
     """
     stmt = select(Job).where(Job.id == job_id).with_for_update()
     result = await session.execute(stmt)
@@ -81,6 +97,15 @@ async def transition_job(
         raise InvalidTransitionError(job.status, to_status)
 
     now = datetime.now(UTC)
+    if (
+        to_status == JobStatus.RUNNING
+        and job.status == JobStatus.RUNNING
+        and not renewal
+        and job.last_heartbeat is not None
+        and job.last_heartbeat > now - LEASE_THRESHOLD
+    ):
+        raise LiveLeaseError()
+
     from_status = job.status
     job.status = to_status
     if message is not None:
@@ -112,6 +137,7 @@ async def transition_job(
         job.next_retry_at = None
         job.progress = 0
         job.completed_at = None
+        job.result_path = None
 
     if (
         job.job_type == JobType.SHOOTOUT_AUDIO

--- a/docs/design/job-system-contract.md
+++ b/docs/design/job-system-contract.md
@@ -42,15 +42,20 @@ Allowed transitions and their sole triggers:
 | From | To | Trigger |
 |---|---|---|
 | PENDING | QUEUED | outbox enqueue |
-| PENDING, QUEUED | CANCELLED | admin cancel |
+| PENDING | RUNNING | self-managed direct claim (SOURCE_SYNC rides no queue) |
+| PENDING | FAILED | pre-claim failure (e.g. the sync auth gate rejects the run) |
+| PENDING, QUEUED | CANCELLED | admin cancel; superseded self-managed run |
 | QUEUED | RUNNING | consumer claim |
-| RUNNING | RUNNING | re-claim after redelivery, only when `last_heartbeat` is stale |
+| RUNNING | RUNNING | lease heartbeat renewal; stale-lease re-claim after redelivery |
 | RUNNING | COMPLETED | handler success |
 | RUNNING | FAILED | handler error; stale-heartbeat reap |
 | RUNNING | CANCELLED | admin cancel |
 | QUEUED, RUNNING | DEAD_LETTERED | consumer base at max redelivery (`read_ct` > max_retries) |
 | FAILED | PENDING | bounded auto-retry (attempt < max_attempts, `next_retry_at` due); admin retry |
 | DEAD_LETTERED | PENDING | admin redrive |
+
+Automatic retry applies to queue-routable types only; self-managed types never
+gain `next_retry_at` (their scheduler owns re-runs).
 
 COMPLETED and CANCELLED have no exits. A rerun is a new shootout (ADR-0004 G2), never a
 transition out of COMPLETED.

--- a/frontend/app/src/api/schema.d.ts
+++ b/frontend/app/src/api/schema.d.ts
@@ -1145,7 +1145,7 @@ export interface paths {
         put?: never;
         /**
          * Cancel Job
-         * @description Cancel a job by setting its status to CANCELLED.
+         * @description Cancel a job through the transition service (reconciles the parent).
          */
         post: operations["cancel_job_api_admin_jobs__job_id__cancel_post"];
         delete?: never;
@@ -1165,7 +1165,7 @@ export interface paths {
         put?: never;
         /**
          * Retry Job
-         * @description Retry a failed or dead-lettered job by resetting it to PENDING.
+         * @description Retry a failed or dead-lettered job through the transition service.
          */
         post: operations["retry_job_api_admin_jobs__job_id__retry_post"];
         delete?: never;

--- a/infra/messaging/src/messaging/consumer_base.py
+++ b/infra/messaging/src/messaging/consumer_base.py
@@ -185,6 +185,21 @@ class BaseConsumer(ABC):
         }
         await self.message_bus.send(self.dead_letter_queue, dlq_message)
         await self.message_bus.archive(self.queue_name, queued_message.msg_id)
+        await self.on_dead_letter(queued_message.message, reason)
+
+    async def on_dead_letter(
+        self,
+        message: dict[str, object],  # noqa: ARG002 - hook signature for overrides
+        reason: str,  # noqa: ARG002
+    ) -> None:
+        """Hook after a message is dead-lettered; runs in the same session.
+
+        Job-backed consumers override this to mark their job row
+        DEAD_LETTERED in the same commit as the DLQ write, so the queue-level
+        and job-row views of "dead-lettered" can never diverge. Default no-op
+        (messages without a job row, e.g. gear-sync events).
+        """
+        return None
 
     def _backoff_seconds(self, attempt: int) -> float:
         """Exponential backoff capped by max_backoff_seconds."""

--- a/infrastructure/migrations/versions/0018_bounded_auto_retry.py
+++ b/infrastructure/migrations/versions/0018_bounded_auto_retry.py
@@ -1,0 +1,25 @@
+"""Bound automatic retry to two attempts total (ADR-0005).
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-07-06
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0018"
+down_revision: str | Sequence[str] | None = "0017"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # max_attempts has no server default (Python-side default only); align the
+    # existing rows with the new application default of 2.
+    op.execute("UPDATE core_jobs SET max_attempts = 2 WHERE max_attempts = 3")
+
+
+def downgrade() -> None:
+    op.execute("UPDATE core_jobs SET max_attempts = 3 WHERE max_attempts = 2")

--- a/model/gts/src/gts/domain/entities/job.py
+++ b/model/gts/src/gts/domain/entities/job.py
@@ -71,7 +71,7 @@ class Job(Entity):
     completed_at: datetime | None = None
     last_heartbeat: datetime | None = None
     attempt: int = 1
-    max_attempts: int = 3
+    max_attempts: int = 2
     next_retry_at: datetime | None = None
     result_path: str | None = None
     error: str | None = None

--- a/model/gts/src/gts/domain/value_objects/job_status.py
+++ b/model/gts/src/gts/domain/value_objects/job_status.py
@@ -53,10 +53,22 @@ class JobStatus(str, Enum):
             True if the transition is valid, False otherwise
         """
         valid_transitions: dict[JobStatus, frozenset[JobStatus]] = {
-            JobStatus.PENDING: frozenset({JobStatus.QUEUED, JobStatus.CANCELLED}),
-            JobStatus.QUEUED: frozenset({JobStatus.RUNNING, JobStatus.CANCELLED}),
+            # QUEUED: outbox enqueue. RUNNING: self-managed direct claim
+            # (SOURCE_SYNC never rides a queue). FAILED: pre-claim failure
+            # (e.g. the auth gate rejects a sync before it starts).
+            JobStatus.PENDING: frozenset(
+                {JobStatus.QUEUED, JobStatus.RUNNING, JobStatus.CANCELLED, JobStatus.FAILED}
+            ),
+            # DEAD_LETTERED: a poison message can exhaust redelivery before
+            # any consumer claims the job.
+            JobStatus.QUEUED: frozenset(
+                {JobStatus.RUNNING, JobStatus.CANCELLED, JobStatus.DEAD_LETTERED}
+            ),
+            # RUNNING self-loop: lease heartbeat renewal and the stale-lease
+            # re-claim after redelivery.
             JobStatus.RUNNING: frozenset(
                 {
+                    JobStatus.RUNNING,
                     JobStatus.COMPLETED,
                     JobStatus.FAILED,
                     JobStatus.CANCELLED,
@@ -67,7 +79,7 @@ class JobStatus(str, Enum):
             JobStatus.FAILED: frozenset({JobStatus.PENDING, JobStatus.DEAD_LETTERED}),
             JobStatus.COMPLETED: frozenset(),
             JobStatus.CANCELLED: frozenset(),
-            # Admin can retry dead-lettered jobs
+            # Admin redrive returns dead-lettered jobs to PENDING
             JobStatus.DEAD_LETTERED: frozenset({JobStatus.PENDING}),
         }
         return target in valid_transitions.get(self, frozenset())

--- a/tests/integration/webapp/test_writer_routing.py
+++ b/tests/integration/webapp/test_writer_routing.py
@@ -1,0 +1,251 @@
+"""Terminal-writer routing through the transition service (DOM-terminal-writer-routing).
+
+Covers the retry bookkeeping (bounded auto-retry, ADR-0005), the retry
+re-projection, parent-cancel semantics, the DLQ job-row coupling, and the
+revived retry sweep.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select, text
+
+from gts.domain.value_objects.job_status import JobStatus, JobType
+from messaging.pgmq_client import PgmqClient
+from webapp.adapters.persistence.models.job import Job
+from webapp.adapters.persistence.models.shootout import Shootout, ShootoutStatus
+from webapp.adapters.persistence.models.user import User
+from webapp.services.job_transitions import (
+    mark_job_dead_lettered,
+    reconcile_parent,
+    transition_job,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.fixture(autouse=True)
+async def _queues(db_session: AsyncSession) -> None:
+    pgmq = PgmqClient(db_session)
+    await pgmq.create_queue("shootout_commands")
+    await pgmq.create_queue("audio_commands")
+
+
+def _job(
+    job_type: JobType = JobType.SHOOTOUT_AUDIO,
+    status: JobStatus = JobStatus.RUNNING,
+    *,
+    user_id=None,
+    parent_job_id=None,
+    entity_id=None,
+    attempt: int = 1,
+) -> Job:
+    return Job(
+        id=uuid4(),
+        user_id=user_id,
+        job_type=job_type,
+        parent_job_id=parent_job_id,
+        entity_id=entity_id or uuid4(),
+        status=status,
+        progress=0,
+        attempt=attempt,
+        max_attempts=2,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestRetryBookkeeping:
+    async def test_failure_under_cap_schedules_auto_retry(self, db_session: AsyncSession) -> None:
+        job = _job(status=JobStatus.RUNNING, attempt=1)
+        db_session.add(job)
+        await db_session.flush()
+
+        await transition_job(db_session, job.id, JobStatus.FAILED, error="boom")
+
+        assert job.next_retry_at is not None
+
+    async def test_failure_at_cap_stays_failed_for_admin(self, db_session: AsyncSession) -> None:
+        job = _job(status=JobStatus.RUNNING, attempt=2)
+        db_session.add(job)
+        await db_session.flush()
+
+        await transition_job(db_session, job.id, JobStatus.FAILED, error="boom")
+
+        assert job.next_retry_at is None
+        assert job.status == JobStatus.FAILED
+
+    async def test_self_managed_type_never_auto_retries(self, db_session: AsyncSession) -> None:
+        job = _job(JobType.SOURCE_SYNC, JobStatus.RUNNING, attempt=1)
+        db_session.add(job)
+        await db_session.flush()
+
+        await transition_job(db_session, job.id, JobStatus.FAILED, error="sync broke")
+
+        assert job.next_retry_at is None
+
+    async def test_retry_claim_consumes_attempt_and_clears_failure(
+        self, db_session: AsyncSession
+    ) -> None:
+        job = _job(status=JobStatus.RUNNING, attempt=1)
+        db_session.add(job)
+        await db_session.flush()
+        await transition_job(db_session, job.id, JobStatus.FAILED, error="boom")
+
+        await transition_job(db_session, job.id, JobStatus.PENDING)
+
+        assert job.attempt == 2
+        assert job.error is None
+        assert job.next_retry_at is None
+        assert job.completed_at is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestParentCancelAndReprojection:
+    @pytest.fixture
+    async def tree(self, db_session: AsyncSession, test_user: User) -> dict:
+        shootout = Shootout(
+            id=uuid4(),
+            user_id=test_user.id,
+            name="Routing Shootout",
+            status=ShootoutStatus.PROCESSING,
+        )
+        db_session.add(shootout)
+        parent = _job(
+            JobType.SHOOTOUT, JobStatus.RUNNING, user_id=test_user.id, entity_id=shootout.id
+        )
+        db_session.add(parent)
+        children = [_job(user_id=test_user.id, parent_job_id=parent.id) for _ in range(2)]
+        db_session.add_all(children)
+        await db_session.flush()
+        return {"shootout": shootout, "parent": parent, "children": children}
+
+    async def test_parent_cancel_projects_shootout_failed(
+        self, db_session: AsyncSession, tree: dict
+    ) -> None:
+        """Parent cancel blocks completion only; the projection reaches FAILED."""
+        await transition_job(db_session, tree["parent"].id, JobStatus.CANCELLED)
+
+        await db_session.refresh(tree["shootout"])
+        assert tree["shootout"].status == ShootoutStatus.FAILED
+        # In-flight children are not cascaded (v1).
+        for child in tree["children"]:
+            await db_session.refresh(child)
+            assert child.status == JobStatus.RUNNING
+
+    async def test_no_master_spawn_under_terminal_parent(
+        self, db_session: AsyncSession, tree: dict
+    ) -> None:
+        """Children finishing under a cancelled parent are never published."""
+        await transition_job(db_session, tree["parent"].id, JobStatus.CANCELLED)
+        for child in tree["children"]:
+            await db_session.execute(
+                text("UPDATE core_jobs SET status = 'completed' WHERE id = :id"),
+                {"id": str(child.id)},
+            )
+
+        await reconcile_parent(db_session, tree["parent"].id)
+        await db_session.commit()
+
+        master = (
+            await db_session.execute(
+                select(Job).where(
+                    Job.parent_job_id == tree["parent"].id,
+                    Job.job_type == JobType.SHOOTOUT_MASTER,
+                )
+            )
+        ).scalar_one_or_none()
+        assert master is None
+
+    async def test_retry_reprojection_revives_failed_run(
+        self, db_session: AsyncSession, tree: dict
+    ) -> None:
+        """A reclaimed failure brings the parent and shootout back to life."""
+        child_a, child_b = tree["children"]
+        await db_session.execute(
+            text("UPDATE core_jobs SET status = 'completed' WHERE id = :id"),
+            {"id": str(child_a.id)},
+        )
+        await transition_job(db_session, child_b.id, JobStatus.FAILED, error="boom")
+        await db_session.refresh(tree["parent"])
+        assert tree["parent"].status == JobStatus.FAILED
+
+        await transition_job(db_session, child_b.id, JobStatus.PENDING)
+
+        await db_session.refresh(tree["parent"])
+        await db_session.refresh(tree["shootout"])
+        assert tree["parent"].status == JobStatus.RUNNING
+        assert tree["parent"].error is None
+        assert tree["shootout"].status == ShootoutStatus.PROCESSING
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestDeadLetterCoupling:
+    async def test_dead_lettered_message_marks_job_row(self, db_session: AsyncSession) -> None:
+        job = _job(status=JobStatus.RUNNING)
+        db_session.add(job)
+        await db_session.flush()
+
+        await mark_job_dead_lettered(
+            db_session,
+            {"payload": {"job_id": str(job.id)}},
+            "max retries exceeded",
+        )
+
+        await db_session.refresh(job)
+        assert job.status == JobStatus.DEAD_LETTERED
+        assert "max retries exceeded" in (job.error or "")
+
+    async def test_completed_job_is_left_alone(self, db_session: AsyncSession) -> None:
+        job = _job(status=JobStatus.RUNNING)
+        db_session.add(job)
+        await db_session.flush()
+        await transition_job(db_session, job.id, JobStatus.COMPLETED)
+
+        await mark_job_dead_lettered(
+            db_session, {"payload": {"job_id": str(job.id)}}, "late redelivery"
+        )
+
+        await db_session.refresh(job)
+        assert job.status == JobStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestRetrySweep:
+    async def test_due_failed_job_is_reclaimed_and_enqueued(
+        self, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import t3k_sync.tasks as tasks_mod
+
+        job = _job(JobType.SHOOTOUT_AUDIO, JobStatus.RUNNING, attempt=1)
+        db_session.add(job)
+        await db_session.flush()
+        await transition_job(db_session, job.id, JobStatus.FAILED, error="boom")
+        # Make the retry due now.
+        await db_session.execute(
+            text("UPDATE core_jobs SET next_retry_at = now() - interval '1 minute' WHERE id = :id"),
+            {"id": str(job.id)},
+        )
+
+        monkeypatch.setattr(tasks_mod, "_test_session", db_session)
+        await tasks_mod.process_pending_retries()
+
+        await db_session.refresh(job)
+        assert job.status == JobStatus.QUEUED
+        assert job.attempt == 2
+
+        result = await db_session.execute(
+            text(
+                "SELECT message FROM pgmq.q_audio_commands "
+                "WHERE message->'payload'->>'job_id' = :jid"
+            ),
+            {"jid": str(job.id)},
+        )
+        assert len(result.fetchall()) == 1

--- a/tests/integration/webapp/test_writer_routing.py
+++ b/tests/integration/webapp/test_writer_routing.py
@@ -249,3 +249,57 @@ class TestRetrySweep:
             {"jid": str(job.id)},
         )
         assert len(result.fetchall()) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestLeaseGuard:
+    async def test_live_lease_blocks_reclaim(self, db_session: AsyncSession) -> None:
+        from webapp.services.job_transitions import LiveLeaseError
+
+        job = _job(status=JobStatus.QUEUED)
+        db_session.add(job)
+        await db_session.flush()
+        await transition_job(db_session, job.id, JobStatus.RUNNING)
+
+        with pytest.raises(LiveLeaseError):
+            await transition_job(db_session, job.id, JobStatus.RUNNING)
+
+    async def test_holder_renewal_refreshes_heartbeat(self, db_session: AsyncSession) -> None:
+        job = _job(status=JobStatus.QUEUED)
+        db_session.add(job)
+        await db_session.flush()
+        await transition_job(db_session, job.id, JobStatus.RUNNING)
+        first_beat = job.last_heartbeat
+
+        await transition_job(db_session, job.id, JobStatus.RUNNING, renewal=True)
+
+        assert job.last_heartbeat is not None
+        assert job.last_heartbeat >= first_beat
+
+    async def test_stale_lease_can_be_reclaimed(self, db_session: AsyncSession) -> None:
+        job = _job(status=JobStatus.QUEUED)
+        db_session.add(job)
+        await db_session.flush()
+        await transition_job(db_session, job.id, JobStatus.RUNNING)
+        await db_session.execute(
+            text(
+                "UPDATE core_jobs SET last_heartbeat = now() - interval '10 minutes' WHERE id = :id"
+            ),
+            {"id": str(job.id)},
+        )
+
+        reclaimed = await transition_job(db_session, job.id, JobStatus.RUNNING)
+
+        assert reclaimed.status == JobStatus.RUNNING
+
+    async def test_retry_claim_clears_result_path(self, db_session: AsyncSession) -> None:
+        job = _job(status=JobStatus.RUNNING)
+        job.result_path = "/app/storage/audio/stale.wav"
+        db_session.add(job)
+        await db_session.flush()
+        await transition_job(db_session, job.id, JobStatus.FAILED, error="boom")
+
+        await transition_job(db_session, job.id, JobStatus.PENDING)
+
+        assert job.result_path is None

--- a/tests/unit/scheduler/test_scheduled_tasks.py
+++ b/tests/unit/scheduler/test_scheduled_tasks.py
@@ -129,7 +129,7 @@ class TestProcessPendingRetries:
     """Test process_pending_retries scheduled task."""
 
     async def test_resets_failed_job_with_retry_time_reached(self, session: AsyncSession) -> None:
-        """FAILED job with next_retry_at <= now is reset to PENDING."""
+        """FAILED job with next_retry_at <= now is reclaimed and enqueued (QUEUED)."""
         from t3k_sync.tasks import process_pending_retries
         from webapp.adapters.persistence.models.job import Job as JobModel
 
@@ -151,7 +151,8 @@ class TestProcessPendingRetries:
         await process_pending_retries()
 
         await session.refresh(job_model)
-        assert job_model.status == JobStatus.PENDING.value
+        assert job_model.status == JobStatus.QUEUED.value
+        assert job_model.attempt == 2
 
     async def test_does_not_retry_job_before_retry_time(self, session: AsyncSession) -> None:
         """FAILED job with next_retry_at in future is not retried yet."""
@@ -202,7 +203,7 @@ class TestProcessPendingRetries:
         assert job_model.status == JobStatus.FAILED.value
 
     async def test_processes_multiple_eligible_retries(self, session: AsyncSession) -> None:
-        """All eligible FAILED jobs are reset to PENDING."""
+        """All eligible FAILED jobs are reclaimed and enqueued."""
         from t3k_sync.tasks import process_pending_retries
         from webapp.adapters.persistence.models.job import Job as JobModel
 
@@ -228,7 +229,7 @@ class TestProcessPendingRetries:
 
         result = await session.execute(
             select(JobModel).where(
-                JobModel.status == JobStatus.PENDING.value,
+                JobModel.status == JobStatus.QUEUED.value,
                 JobModel.id.in_(job_ids),
             )
         )

--- a/tests/unit/webapp/test_status_writer_guard.py
+++ b/tests/unit/webapp/test_status_writer_guard.py
@@ -27,27 +27,21 @@ RAW_WRITE = re.compile(r"UPDATE\s+(?:core_jobs|core_shootouts)\s+SET\s+status", 
 
 # file (repo-relative) -> exact number of status writes sanctioned there.
 ALLOWED: dict[str, int] = {
-    # The transition service itself: transition_job + reconcile_parent projection.
-    "apps/webapp/src/webapp/services/job_transitions.py": 5,
+    # The transition service itself: transition_job, the parent-cancel
+    # projection, and the reconcile_parent projection writes.
+    "apps/webapp/src/webapp/services/job_transitions.py": 7,
     # The outbox: exactly the PENDING -> QUEUED enqueue edge.
     "apps/webapp/src/webapp/services/job_dispatch.py": 1,
     # The run-request edge: shootout DRAFT -> PENDING at the process trigger.
     "apps/webapp/src/webapp/api/v1/shootouts.py": 1,
     # --- Legacy writers, shrink only ---
-    # DOM-terminal-writer-routing: admin cancel + admin retry.
-    "apps/webapp/src/webapp/api/admin.py": 2,
-    # DOM-terminal-writer-routing: user retry.
-    "apps/webapp/src/webapp/api/v1/jobs.py": 1,
     # JOB-idempotent-consume + DOM-shootout-finalise: claim, complete, fail,
     # and the master path's rogue parent/shootout projection.
     "apps/audio_worker/src/audio_worker/consumer.py": 8,
     # JOB-idempotent-consume: orchestrator claim + fan-out dispatch flips.
     "apps/shootout_orchestrator/src/shootout_orchestrator/consumer.py": 3,
-    # DOM-reaper-render-race + DOM-terminal-writer-routing: raw-SQL reaper and
-    # retry sweep writes.
-    "apps/t3k_sync/src/t3k_sync/tasks.py": 3,
-    # DOM-terminal-writer-routing: the SOURCE_SYNC lifecycle writer.
-    "apps/t3k_sync/src/t3k_sync/source_sync.py": 1,
+    # DOM-reaper-render-race: the raw-SQL stale-job reaper (both paths).
+    "apps/t3k_sync/src/t3k_sync/tasks.py": 2,
     # Domain->ORM mapping in the shootout repository save path.
     "apps/webapp/src/webapp/adapters/persistence/repositories/shootout_repository.py": 1,
     # DEBT-backend-dead-modules: the unused job repository write path.


### PR DESCRIPTION
DOM-terminal-writer-routing from the job-reliability cluster (design authority: docs/design/job-system-contract.md; decision: ADR-0005).

- Admin cancel/retry, user retry, the scheduled retry sweep, and the SOURCE_SYNC lifecycle route through transition_job; raw-SQL sweep writes and direct ORM writers deleted.
- The dormant auto-retry path is wired end to end: a routable failure under the attempt cap sets next_retry_at (120 s backoff); the sweep claims FAILED -> PENDING (attempt increment, error cleared, parent re-projection) and re-enqueues through the outbox; at the cap the job stays FAILED for admin. max_attempts default 2 per ADR-0005 (migration 0018 aligns existing rows). Self-managed types (SOURCE_SYNC) never gain next_retry_at - their scheduler owns re-runs.
- Consumer base gains an on_dead_letter hook; the audio worker and orchestrator mark their job row DEAD_LETTERED in the same commit as the queue-DLQ envelope write - the job-row and queue-level dead-letter views can no longer diverge.
- Parent-cancel semantics per ADR-0005: shootout projects to FAILED immediately, in-flight children finish but a terminal parent blocks master spawn. Retry re-projection revives a FAILED unpublished run (never out of COMPLETED).
- Transition table gains the self-managed edges (PENDING->RUNNING claim, PENDING->FAILED pre-claim failure, QUEUED->DEAD_LETTERED poison, RUNNING self-loop heartbeat/re-claim); domain value object + contract doc updated together.
- Status-writer guard allowlist shrinks by four files (admin, jobs route, source_sync, one raw-SQL sweep write).

Gate: full worktree gate green.