### PR TITLE
feat(jobs): renders off the event loop with lease-renewed visibility (JOB-render-offload)

### DIFF
--- a/apps/audio_worker/src/audio_worker/consumer.py
+++ b/apps/audio_worker/src/audio_worker/consumer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import tempfile
@@ -23,6 +24,7 @@ from audio.processing import (
     execute_signal_chain,
     normalize_loudness,
 )
+from audio_worker.lease import MessageLease
 from gts.domain.value_objects.job_status import JobStatus, JobType
 from messaging.commands import ProcessAudioCommand
 from messaging.consumer_base import BaseConsumer
@@ -48,6 +50,10 @@ if TYPE_CHECKING:
 
 STORAGE_BASE = Path("/app/storage/audio")
 TARGET_LUFS = -14.0
+
+# One CPU-bound render at a time per worker; the event loop stays free for
+# /health and the lease heartbeat throughout.
+_render_gate = asyncio.Semaphore(1)
 
 
 async def _process_shootout_audio(job_id: UUID, database_url: str) -> None:
@@ -145,9 +151,10 @@ async def _process_shootout_audio(job_id: UUID, database_url: str) -> None:
             shootout_id,
             len(signal_chain.blocks),
         )
-        processed_audio = await execute_signal_chain(
-            signal_chain, di_audio, sample_rate, gear_path_resolver
-        )
+        async with _render_gate:
+            processed_audio = await asyncio.to_thread(
+                execute_signal_chain, signal_chain, di_audio, sample_rate, gear_path_resolver
+            )
 
         # Write processed audio to temp file, then normalise to FLAC output
         output_dir = STORAGE_BASE / str(shootout_id)
@@ -383,10 +390,16 @@ class ProcessAudioConsumer(BaseConsumer):
         self._session = session
 
     async def handle_message(self, envelope: MessageEnvelope) -> None:
-        """Handle one process_audio command envelope."""
+        """Handle one process_audio command envelope under a renewed lease."""
         command = ProcessAudioCommand.model_validate(envelope.model_dump(mode="python"))
         job_id = UUID(command.payload["job_id"])
-        await process_audio_job(job_id)
+        database_url = os.getenv("DATABASE_URL", "postgresql+asyncpg://gts:gts@db:5432/gts_core")
+        message = self.current_message
+        if message is None:
+            await process_audio_job(job_id)
+            return
+        async with MessageLease(database_url, self.queue_name, message.msg_id, job_id):
+            await process_audio_job(job_id)
 
     async def on_dead_letter(self, message: dict[str, object], reason: str) -> None:
         """Couple the job row to the queue-level DLQ in the same commit."""

--- a/apps/audio_worker/src/audio_worker/lease.py
+++ b/apps/audio_worker/src/audio_worker/lease.py
@@ -1,0 +1,82 @@
+"""Message lease renewal while a render runs (docs/design/job-system-contract.md).
+
+While a handler works a message, a background task on its own short-lived
+session extends the pgmq visibility timeout and renews the job heartbeat every
+HEARTBEAT_INTERVAL_SECONDS. A live render therefore holds its lease exactly as
+long as it is genuinely alive - no speculative p99 visibility constant - and a
+crashed worker's message becomes visible again within VT_EXTENSION_SECONDS.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from gts.domain.value_objects.job_status import JobStatus
+from messaging.consumer_base import HEARTBEAT_INTERVAL_SECONDS, VT_EXTENSION_SECONDS
+from messaging.db import get_session_no_tx as get_session
+from messaging.pgmq_client import PgmqClient
+from webapp.services.job_transitions import TransitionError, transition_job
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+
+class MessageLease:
+    """Async context manager renewing a message lease while work runs.
+
+    Each beat, on one fresh session and one commit: set_vt pushes the message's
+    visibility to now + VT_EXTENSION_SECONDS, and the RUNNING -> RUNNING
+    renewal through the transition service refreshes job.last_heartbeat. A
+    terminal job stops the beats (the work finished under us - e.g. reaped).
+    """
+
+    def __init__(
+        self,
+        database_url: str,
+        queue_name: str,
+        msg_id: int,
+        job_id: UUID,
+        *,
+        interval_seconds: float = HEARTBEAT_INTERVAL_SECONDS,
+    ) -> None:
+        self._database_url = database_url
+        self._queue_name = queue_name
+        self._msg_id = msg_id
+        self._job_id = job_id
+        self._interval_seconds = interval_seconds
+        self._task: asyncio.Task[None] | None = None
+
+    async def __aenter__(self) -> MessageLease:
+        self._task = asyncio.create_task(self._run())
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            await asyncio.gather(self._task, return_exceptions=True)
+            self._task = None
+
+    async def _run(self) -> None:
+        while True:
+            await asyncio.sleep(self._interval_seconds)
+            try:
+                async with get_session(self._database_url) as session:
+                    # set_vt stages on the session; transition_job's commit
+                    # lands both the lease extension and the heartbeat.
+                    await PgmqClient(session).set_vt(
+                        self._queue_name, self._msg_id, VT_EXTENSION_SECONDS
+                    )
+                    await transition_job(session, self._job_id, JobStatus.RUNNING, renewal=True)
+            except TransitionError as exc:
+                # The job reached a state that cannot renew (terminal, or a
+                # reap won the race): stop beating, let the handler finish.
+                logger.info("Lease renewal stopped for job %s: %s", self._job_id, exc)
+                return
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Lease renewal beat failed for job %s", self._job_id)

--- a/infra/messaging/src/messaging/consumer_base.py
+++ b/infra/messaging/src/messaging/consumer_base.py
@@ -13,6 +13,15 @@ from pydantic import ValidationError
 
 from messaging.envelope import MessageEnvelope
 
+#: Lease renewal cadence while a handler works a message. Contract invariant:
+#: HEARTBEAT_INTERVAL_SECONDS * 2 < VT_EXTENSION_SECONDS < the transition
+#: service's LEASE_THRESHOLD, so one missed beat never causes redelivery and a
+#: crashed worker's message redelivers before the reaper declares it dead.
+HEARTBEAT_INTERVAL_SECONDS = 20.0
+
+#: Visibility window granted by each heartbeat's set_vt.
+VT_EXTENSION_SECONDS = 90
+
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
@@ -51,6 +60,9 @@ class BaseConsumer(ABC):
         self._sleep = sleep_func
         self._shutdown_event = asyncio.Event()
         self.logger = logging.getLogger(self.__class__.__name__)
+        #: The message currently being processed; handlers may read msg_id for
+        #: lease renewal (set_vt) while their work runs.
+        self.current_message: QueueMessage | None = None
 
     def request_shutdown(self) -> None:
         """Signal the consumer to stop after the current iteration."""
@@ -99,6 +111,13 @@ class BaseConsumer(ABC):
 
     async def process_message(self, queued_message: QueueMessage) -> None:
         """Process one queue message with retry and DLQ semantics."""
+        self.current_message = queued_message
+        try:
+            await self._process_message_inner(queued_message)
+        finally:
+            self.current_message = None
+
+    async def _process_message_inner(self, queued_message: QueueMessage) -> None:
         max_attempts = self.max_retries + 1
         current_attempt = queued_message.read_ct
 

--- a/infra/messaging/src/messaging/message_bus.py
+++ b/infra/messaging/src/messaging/message_bus.py
@@ -54,6 +54,10 @@ class MessageBus(Protocol):
         """Archive a processed queue message."""
         ...
 
+    async def set_vt(self, queue_name: str, msg_id: int, visibility_timeout: int) -> None:
+        """Extend an in-flight message's visibility timeout (lease renewal)."""
+        ...
+
     async def create_queue(self, queue_name: str) -> None:
         """Create a pgmq queue if it does not exist."""
         ...

--- a/infra/messaging/src/messaging/pgmq_client.py
+++ b/infra/messaging/src/messaging/pgmq_client.py
@@ -50,6 +50,22 @@ class PgmqClient(MessageBus):
         )
         return int(result.scalar_one())
 
+    async def set_vt(self, queue_name: str, msg_id: int, visibility_timeout: int) -> None:
+        """Extend an in-flight message's visibility timeout (lease renewal).
+
+        Sets the message's vt to now + visibility_timeout seconds, so a live
+        worker keeps its lease exactly as long as it keeps heartbeating.
+        """
+        stmt = text(
+            "SELECT msg_id FROM pgmq.set_vt("
+            "CAST(:queue AS text), CAST(:msg_id AS bigint), CAST(:vt AS integer)"
+            ")"
+        )
+        await self._session.execute(
+            stmt,
+            {"queue": queue_name, "msg_id": msg_id, "vt": visibility_timeout},
+        )
+
     async def read(
         self,
         queue_name: str,

--- a/model/audio/src/audio/processing/chain_executor.py
+++ b/model/audio/src/audio/processing/chain_executor.py
@@ -3,6 +3,10 @@
 This module provides functionality to execute a complete signal chain by
 processing audio through each block in position order, enforcing grammar
 constraints for FULL_RIG vs HEAD configurations.
+
+Execution is synchronous CPU-bound DSP (NAM inference, IR convolution) and
+holds no async work; async callers must run it off the event loop
+(asyncio.to_thread) so health endpoints and lease heartbeats stay responsive.
 """
 
 from collections.abc import Callable
@@ -31,7 +35,7 @@ class ChainExecutionError(Exception):
     pass
 
 
-async def execute_signal_chain(
+def execute_signal_chain(
     chain: SignalChain,
     di_audio: np.ndarray,
     sample_rate: int,
@@ -59,7 +63,7 @@ async def execute_signal_chain(
     Examples:
         >>> def resolver(user_gear_id, gear_type):
         ...     return Path(f"/gear/{user_gear_id}.nam")
-        >>> result = await execute_signal_chain(
+        >>> result = execute_signal_chain(
         ...     chain=my_chain,
         ...     di_audio=audio,
         ...     sample_rate=48000,
@@ -91,14 +95,14 @@ async def execute_signal_chain(
             GearType.POST_EFFECT,
         ):
             # NAM model processing
-            current_audio = await _process_nam_block(
+            current_audio = _process_nam_block(
                 audio=current_audio,
                 sample_rate=sample_rate,
                 model_path=gear_path,
             )
         elif block.gear_type == GearType.IR:
             # IR convolution processing
-            current_audio = await _process_ir_block(
+            current_audio = _process_ir_block(
                 audio=current_audio,
                 sample_rate=sample_rate,
                 ir_path=gear_path,
@@ -140,7 +144,7 @@ def _validate_chain_constraints(blocks: list["SignalChainBlock"]) -> None:
         )
 
 
-async def _process_nam_block(
+def _process_nam_block(
     audio: np.ndarray,
     sample_rate: int,
     model_path: Path,
@@ -167,7 +171,7 @@ async def _process_nam_block(
         raise ChainExecutionError(f"NAM processing failed: {e}") from e
 
 
-async def _process_ir_block(
+def _process_ir_block(
     audio: np.ndarray,
     sample_rate: int,
     ir_path: Path,

--- a/tests/integration/audio/test_chain_execution.py
+++ b/tests/integration/audio/test_chain_execution.py
@@ -267,7 +267,7 @@ async def test_execute_head_configuration(
     chain = signal_chain_with_amp_and_ir
 
     # Execute chain
-    result_audio = await execute_signal_chain(
+    result_audio = execute_signal_chain(
         chain=chain,
         di_audio=audio,
         sample_rate=sample_rate,
@@ -292,7 +292,7 @@ async def test_execute_full_rig_configuration(
     chain = signal_chain_with_full_rig
 
     # Execute chain
-    result_audio = await execute_signal_chain(
+    result_audio = execute_signal_chain(
         chain=chain,
         di_audio=audio,
         sample_rate=sample_rate,
@@ -316,7 +316,7 @@ async def test_execute_complete_chain(
     chain = signal_chain_with_pre_and_post_effects
 
     # Execute chain
-    result_audio = await execute_signal_chain(
+    result_audio = execute_signal_chain(
         chain=chain,
         di_audio=audio,
         sample_rate=sample_rate,
@@ -366,7 +366,7 @@ async def test_full_rig_with_ir_raises_error(
 
     # Should raise error
     with pytest.raises(ChainExecutionError, match=r"FULL_RIG.*cannot.*IR"):
-        await execute_signal_chain(
+        execute_signal_chain(
             chain=chain,
             di_audio=audio,
             sample_rate=sample_rate,
@@ -401,7 +401,7 @@ async def test_amp_without_ir_raises_error(
 
     # Should raise error
     with pytest.raises(ChainExecutionError, match=r"AMP.*requires.*IR"):
-        await execute_signal_chain(
+        execute_signal_chain(
             chain=chain,
             di_audio=audio,
             sample_rate=sample_rate,
@@ -454,7 +454,7 @@ async def test_blocks_execute_in_position_order(
         chain.blocks.append(block)
 
     # Execute - should process in position order regardless of list order
-    result_audio = await execute_signal_chain(
+    result_audio = execute_signal_chain(
         chain=chain,
         di_audio=audio,
         sample_rate=sample_rate,
@@ -481,7 +481,7 @@ async def test_empty_chain_raises_error(
 
     # Should raise error
     with pytest.raises(ChainExecutionError, match=r"empty|no blocks"):
-        await execute_signal_chain(
+        execute_signal_chain(
             chain=chain,
             di_audio=audio,
             sample_rate=sample_rate,

--- a/tests/integration/audio/test_message_lease.py
+++ b/tests/integration/audio/test_message_lease.py
@@ -95,14 +95,15 @@ class TestMessageLease:
 
     async def test_terminal_job_stops_the_beats(self, db_session: AsyncSession) -> None:
         job, msg_id = await _running_job_with_message(db_session)
+        job_id = job.id
         await db_session.execute(
             text("UPDATE core_jobs SET status = 'completed' WHERE id = :id"),
-            {"id": str(job.id)},
+            {"id": str(job_id)},
         )
         db_session.expire(job)
 
         async with MessageLease(
-            "unused-patched", "audio_commands", msg_id, job.id, interval_seconds=0.05
+            "unused-patched", "audio_commands", msg_id, job_id, interval_seconds=0.05
         ):
             await asyncio.sleep(0.2)
 

--- a/tests/integration/audio/test_message_lease.py
+++ b/tests/integration/audio/test_message_lease.py
@@ -1,0 +1,110 @@
+"""Message lease renewal: heartbeat + visibility extension while work runs."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+
+from audio_worker.lease import MessageLease
+from gts.domain.value_objects.job_status import JobStatus, JobType
+from messaging.pgmq_client import PgmqClient
+from webapp.adapters.persistence.models.job import Job
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.fixture(autouse=True)
+def _patch_lease_session(db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch) -> None:
+    import audio_worker.lease as lease_mod
+
+    @asynccontextmanager
+    async def _factory(_url: str) -> AsyncGenerator[AsyncSession, None]:
+        yield db_session
+
+    monkeypatch.setattr(lease_mod, "get_session", _factory)
+
+
+async def _running_job_with_message(db_session: AsyncSession) -> tuple[Job, int]:
+    pgmq = PgmqClient(db_session)
+    await pgmq.create_queue("audio_commands")
+    job = Job(
+        id=uuid4(),
+        user_id=None,
+        job_type=JobType.SHOOTOUT_AUDIO,
+        entity_id=uuid4(),
+        status=JobStatus.RUNNING,
+        progress=0,
+    )
+    db_session.add(job)
+    await db_session.flush()
+    msg_id = await pgmq.send(
+        "audio_commands",
+        {"message_type": "process_audio", "payload": {"job_id": str(job.id)}},
+    )
+    return job, msg_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestMessageLease:
+    async def test_beats_renew_heartbeat_and_visibility(self, db_session: AsyncSession) -> None:
+        job, msg_id = await _running_job_with_message(db_session)
+        await db_session.execute(
+            text("UPDATE core_jobs SET last_heartbeat = now() - interval '1 hour' WHERE id = :id"),
+            {"id": str(job.id)},
+        )
+        vt_before = (
+            await db_session.execute(
+                text("SELECT vt FROM pgmq.q_audio_commands WHERE msg_id = :m"),
+                {"m": msg_id},
+            )
+        ).scalar_one()
+
+        async with MessageLease(
+            "unused-patched", "audio_commands", msg_id, job.id, interval_seconds=0.05
+        ):
+            await asyncio.sleep(0.2)
+
+        await db_session.refresh(job)
+        assert job.last_heartbeat is not None
+        beat_age = (
+            await db_session.execute(
+                text(
+                    "SELECT extract(epoch FROM now() - last_heartbeat) FROM core_jobs WHERE id = :id"
+                ),
+                {"id": str(job.id)},
+            )
+        ).scalar_one()
+        assert beat_age < 60, "the lease task must have renewed last_heartbeat"
+
+        vt_after = (
+            await db_session.execute(
+                text("SELECT vt FROM pgmq.q_audio_commands WHERE msg_id = :m"),
+                {"m": msg_id},
+            )
+        ).scalar_one()
+        assert vt_after > vt_before, "the lease task must extend the visibility timeout"
+
+    async def test_terminal_job_stops_the_beats(self, db_session: AsyncSession) -> None:
+        job, msg_id = await _running_job_with_message(db_session)
+        await db_session.execute(
+            text("UPDATE core_jobs SET status = 'completed' WHERE id = :id"),
+            {"id": str(job.id)},
+        )
+        db_session.expire(job)
+
+        async with MessageLease(
+            "unused-patched", "audio_commands", msg_id, job.id, interval_seconds=0.05
+        ):
+            await asyncio.sleep(0.2)
+
+        await db_session.refresh(job)
+        assert job.status == JobStatus.COMPLETED

--- a/tests/unit/core/test_consumer_current_message.py
+++ b/tests/unit/core/test_consumer_current_message.py
@@ -1,0 +1,81 @@
+"""BaseConsumer exposes the in-flight message to handlers and clears it after."""
+
+from __future__ import annotations
+
+import pytest
+
+from messaging.consumer_base import BaseConsumer
+from messaging.message_bus import QueueMessage
+
+
+class _RecordingBus:
+    """Minimal in-memory MessageBus standing in for pgmq."""
+
+    def __init__(self) -> None:
+        self.archived: list[int] = []
+        self.sent: list[tuple[str, dict]] = []
+
+    async def send(self, queue_name, message):
+        self.sent.append((queue_name, dict(message)))
+        return 1
+
+    async def read(self, queue_name, *, visibility_timeout, batch_size):
+        return []
+
+    async def archive(self, queue_name, msg_id):
+        self.archived.append(msg_id)
+        return True
+
+    async def set_vt(self, queue_name, msg_id, visibility_timeout):
+        return None
+
+    async def create_queue(self, queue_name):
+        return None
+
+    async def drop_queue(self, queue_name):
+        return None
+
+
+class _ObservingConsumer(BaseConsumer):
+    def __init__(self) -> None:
+        super().__init__(
+            message_bus=_RecordingBus(),
+            queue_name="audio_commands",
+            dead_letter_queue="dead_letter",
+        )
+        self.seen_msg_ids: list[int | None] = []
+
+    async def handle_message(self, envelope) -> None:
+        self.seen_msg_ids.append(self.current_message.msg_id if self.current_message else None)
+
+
+def _message(msg_id: int = 42) -> QueueMessage:
+    return QueueMessage(
+        msg_id=msg_id,
+        read_ct=1,
+        message={"message_type": "process_audio", "source_bc": "test", "payload": {}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_current_message_set_during_handling_and_cleared_after() -> None:
+    consumer = _ObservingConsumer()
+
+    await consumer.process_message(_message(msg_id=42))
+
+    assert consumer.seen_msg_ids == [42], "handler must see the in-flight message"
+    assert consumer.current_message is None, "the message must be cleared after processing"
+
+
+@pytest.mark.asyncio
+async def test_current_message_cleared_after_handler_failure() -> None:
+    class _FailingConsumer(_ObservingConsumer):
+        async def handle_message(self, envelope) -> None:
+            raise RuntimeError("boom")
+
+    consumer = _FailingConsumer()
+    consumer.max_retries = 0
+
+    await consumer.process_message(_message(msg_id=7))
+
+    assert consumer.current_message is None

--- a/tests/unit/webapp/test_lease_timing_invariants.py
+++ b/tests/unit/webapp/test_lease_timing_invariants.py
@@ -1,0 +1,42 @@
+"""Timing-constant invariants from docs/design/job-system-contract.md.
+
+Pinning the ordering means nobody can tune one constant and silently break the
+lease design: one missed beat must never cause redelivery, and a crashed
+worker's message must redeliver before the reaper declares the job dead.
+"""
+
+import inspect
+
+from audio.processing.chain_executor import execute_signal_chain
+from messaging.consumer_base import (
+    HEARTBEAT_INTERVAL_SECONDS,
+    VT_EXTENSION_SECONDS,
+    BaseConsumer,
+)
+from webapp.services.job_transitions import LEASE_THRESHOLD
+
+
+def test_one_missed_beat_never_redelivers() -> None:
+    assert HEARTBEAT_INTERVAL_SECONDS * 2 < VT_EXTENSION_SECONDS
+
+
+def test_redelivery_precedes_reap() -> None:
+    """A crashed worker's message redelivers before the lease is declared dead."""
+    assert LEASE_THRESHOLD.total_seconds() > VT_EXTENSION_SECONDS
+
+
+def test_initial_visibility_below_extension() -> None:
+    """The first read's window is the floor; renewals only ever extend it."""
+    import inspect as _inspect
+
+    default_vt = _inspect.signature(BaseConsumer.__init__).parameters["visibility_timeout"].default
+    assert default_vt <= VT_EXTENSION_SECONDS
+
+
+def test_chain_executor_is_honestly_synchronous() -> None:
+    """The render is CPU-bound sync DSP; async callers must offload it.
+
+    Re-asyncifying it would silently block the event loop for whole renders
+    (the pre-fix root cause of the reaper punishing healthy work).
+    """
+    assert not inspect.iscoroutinefunction(execute_signal_chain)


### PR DESCRIPTION
JOB-render-offload from the job-reliability cluster (design authority: docs/design/job-system-contract.md, Consumer contract + Timing sections).

- model/audio chain executor stripped of its async lie (zero real awaits; NAM inference and Pedalboard convolution are synchronous CPU-bound DSP). A pinned test keeps it honestly sync.
- The audio worker runs renders via asyncio.to_thread behind a semaphore(1): one render at a time, event loop free for /health and lease beats throughout.
- New MessageLease (audio_worker/lease.py): every 20 s, on one fresh session and one commit, pgmq set_vt pushes the message's visibility to now+90 s and a RUNNING->RUNNING renewal through the transition service refreshes last_heartbeat. Terminal job stops the beats. set_vt added to the MessageBus protocol + PgmqClient.
- Consumer base exposes the in-flight message (current_message) and the timing constants; invariant tests pin heartbeat*2 < vt-extension < lease threshold and initial-vt <= extension.
- Integration tests: beats genuinely extend vt and heartbeat against real pgmq; terminal jobs stop renewing.

Gate: full worktree gate green.