### PR TITLE
feat(domain): manifest table + versioned render substrate (DOM-manifest-table)

### DIFF
--- a/apps/audio_worker/src/audio_worker/consumer.py
+++ b/apps/audio_worker/src/audio_worker/consumer.py
@@ -110,6 +110,7 @@ async def _process_shootout_audio(job_id: UUID, database_url: str) -> None:
                 raise ValueError(f"Shootout {shootout.id} has no DI track")
 
             shootout_id = shootout.id
+            render_version = shootout.render_version
 
             # Pre-load gear paths for chain blocks
             user_gear_ids = [
@@ -156,8 +157,10 @@ async def _process_shootout_audio(job_id: UUID, database_url: str) -> None:
                 execute_signal_chain, signal_chain, di_audio, sample_rate, gear_path_resolver
             )
 
-        # Write processed audio to temp file, then normalise to FLAC output
-        output_dir = STORAGE_BASE / str(shootout_id)
+        # Write processed audio to temp file, then normalise into the
+        # per-version directory (ADR-0004): a render only ever writes inside
+        # its own version and never touches files an existing manifest pins.
+        output_dir = STORAGE_BASE / str(shootout_id) / f"v{render_version}"
         output_dir.mkdir(parents=True, exist_ok=True)
         output_path = output_dir / f"{shootout_chain_id}.wav"
 
@@ -186,6 +189,7 @@ async def _process_shootout_audio(job_id: UUID, database_url: str) -> None:
                 integrated_lufs=result_lufs,
                 peak_dbfs=result_peak,
                 waveform=waveform,
+                version=render_version,
             )
             session.add(segment)
 
@@ -266,15 +270,21 @@ async def _process_shootout_master(job_id: UUID, database_url: str) -> None:
             if shootout is None:
                 raise ValueError(f"Shootout {shootout_id} not found")
 
-        # Collect and concatenate audio from all chain segments (ordered by chain position)
+        # Collect and concatenate audio from all chain segments (ordered by
+        # chain position). Segments are pinned to this run's render version -
+        # never segments[0], which is undefined after a redelivery or rerun.
+        render_version = shootout.render_version
         sorted_chains = sorted(shootout.chains, key=lambda c: c.position)
         all_audio: list[np.ndarray] = []
         sample_rate: int | None = None
 
         for chain in sorted_chains:
-            if not chain.segments:
-                raise ProcessingError(f"Chain {chain.id} has no audio segments")
-            segment = chain.segments[0]  # One segment per chain
+            versioned = [seg for seg in chain.segments if seg.version == render_version]
+            if not versioned:
+                raise ProcessingError(
+                    f"Chain {chain.id} has no audio segment for version {render_version}"
+                )
+            segment = versioned[0]
             seg_path = Path(segment.file_path)
             if not seg_path.exists():
                 raise ProcessingError(f"Segment file not found: {seg_path}")
@@ -292,8 +302,8 @@ async def _process_shootout_master(job_id: UUID, database_url: str) -> None:
         # Concatenate all chain audio
         master_audio = np.concatenate(all_audio)
 
-        # Write to temp, normalise to master FLAC
-        output_dir = STORAGE_BASE / str(shootout_id)
+        # Write to temp, normalise to master FLAC in this run's version dir
+        output_dir = STORAGE_BASE / str(shootout_id) / f"v{render_version}"
         output_dir.mkdir(parents=True, exist_ok=True)
         master_path = output_dir / "master.wav"
 

--- a/apps/webapp/src/webapp/adapters/persistence/models/shootout.py
+++ b/apps/webapp/src/webapp/adapters/persistence/models/shootout.py
@@ -6,7 +6,18 @@ import uuid
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import Float, ForeignKey, Index, Integer, String, Text
+from sqlalchemy import (
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship, synonym
 
 from .base import (
@@ -137,6 +148,10 @@ class Shootout(UUIDMixin, TimestampMixin, Base):
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     title: Mapped[str] = synonym("name")  # Alias for backwards compatibility
+    # ADR-0004 versioned substrate: the run generation this shootout is on.
+    # Incremented in the rerun run-request transaction (DOM-rerun-versioning);
+    # the first run renders as version 1.
+    render_version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     status: Mapped[ShootoutStatus] = mapped_column(
         EnumByValue(ShootoutStatus),
@@ -264,6 +279,9 @@ class AudioSegment(UUIDMixin, Base):
     integrated_lufs: Mapped[float] = mapped_column(Float, nullable=False)
     peak_dbfs: Mapped[float] = mapped_column(Float, nullable=False)
     waveform: Mapped[Any] = mapped_column(WaveformDataType(), nullable=True)
+    # ADR-0004 versioned substrate: the render generation this segment belongs
+    # to. (shootout_chain_id, version) is the segment idempotency key.
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
 
     # Relationship
     shootout_chain: Mapped[ShootoutChain] = relationship(
@@ -272,5 +290,39 @@ class AudioSegment(UUIDMixin, Base):
         lazy="raise",
     )
 
-    # Index
-    __table_args__ = (Index("ix_audio_segments_chain_id", "shootout_chain_id"),)
+    __table_args__ = (
+        Index("ix_audio_segments_chain_id", "shootout_chain_id"),
+        UniqueConstraint("shootout_chain_id", "version", name="uq_audio_segments_chain_version"),
+    )
+
+
+class ShootoutManifest(UUIDMixin, Base):
+    """Immutable, versioned render-time snapshot of a shootout (ADR-0004).
+
+    Insert-only: there is no application UPDATE or targeted-DELETE path; the
+    only deletion is the FK cascade when an owner deletes the whole shootout.
+    The payload is a self-contained JSONB snapshot with no foreign keys into
+    chains, segments, signal chains, or gear, which is what makes a published
+    manifest immune to the signal-chain CASCADE. The field-level payload
+    schema is owned by docs/design/shootout-artefact-contract.md.
+    """
+
+    __tablename__ = "core_shootout_manifests"
+
+    shootout_id: Mapped[uuid.UUID] = mapped_column(
+        UuidType(),
+        ForeignKey("core_shootouts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    version: Mapped[int] = mapped_column(Integer, nullable=False)
+    schema_version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    payload: Mapped[Any] = mapped_column(JSONB, nullable=False)
+    created_at: Mapped[Any] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    shootout: Mapped[Shootout] = relationship("Shootout", lazy="raise")
+
+    __table_args__ = (
+        UniqueConstraint("shootout_id", "version", name="uq_shootout_manifests_shootout_version"),
+    )

--- a/infrastructure/migrations/versions/0019_manifest_versioned_substrate.py
+++ b/infrastructure/migrations/versions/0019_manifest_versioned_substrate.py
@@ -1,0 +1,104 @@
+"""Manifest table and the versioned render substrate (ADR-0004).
+
+core_shootout_manifests holds the immutable, versioned render-time snapshot;
+Shootout.render_version and AudioSegment.version are the versioned substrate
+the finalise and idempotent-consume paths key on. Existing duplicate segments
+(the pre-fix redelivery shape) are numbered by insertion order before the
+unique constraint lands, so the adversarial shape migrates instead of failing.
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-07-06
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "0019"
+down_revision: str | Sequence[str] | None = "0018"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "core_shootout_manifests",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "shootout_id",
+            sa.Uuid(),
+            sa.ForeignKey("core_shootouts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("schema_version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("payload", JSONB(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint(
+            "shootout_id", "version", name="uq_shootout_manifests_shootout_version"
+        ),
+    )
+
+    op.add_column(
+        "core_shootouts",
+        sa.Column("render_version", sa.Integer(), nullable=False, server_default="1"),
+    )
+    op.add_column(
+        "core_audio_segments",
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+    )
+
+    # Adversarial shape: pre-fix redelivery inserted duplicate segments per
+    # chain with nothing to prevent it. Number duplicates by insertion order
+    # (UUIDv7 primary keys are time-ordered) so the unique constraint can land
+    # without data loss; the newest duplicate gets the highest version.
+    op.execute(
+        """
+        WITH numbered AS (
+            SELECT id, row_number() OVER (
+                PARTITION BY shootout_chain_id ORDER BY id
+            ) AS rn
+            FROM core_audio_segments
+        )
+        UPDATE core_audio_segments s
+        SET version = n.rn
+        FROM numbered n
+        WHERE s.id = n.id AND n.rn > 1
+        """
+    )
+    # Align each shootout's render_version with its highest segment version so
+    # the next run's version is monotonic.
+    op.execute(
+        """
+        UPDATE core_shootouts sh
+        SET render_version = sub.maxv
+        FROM (
+            SELECT sc.shootout_id, max(a.version) AS maxv
+            FROM core_audio_segments a
+            JOIN core_shootout_chains sc ON sc.id = a.shootout_chain_id
+            GROUP BY sc.shootout_id
+        ) sub
+        WHERE sh.id = sub.shootout_id AND sub.maxv > 1
+        """
+    )
+
+    op.create_unique_constraint(
+        "uq_audio_segments_chain_version",
+        "core_audio_segments",
+        ["shootout_chain_id", "version"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_audio_segments_chain_version", "core_audio_segments", type_="unique")
+    op.drop_column("core_audio_segments", "version")
+    op.drop_column("core_shootouts", "render_version")
+    op.drop_table("core_shootout_manifests")

--- a/infrastructure/migrations/versions/0019_manifest_versioned_substrate.py
+++ b/infrastructure/migrations/versions/0019_manifest_versioned_substrate.py
@@ -74,19 +74,26 @@ def upgrade() -> None:
         WHERE s.id = n.id AND n.rn > 1
         """
     )
-    # Align each shootout's render_version with its highest segment version so
-    # the next run's version is monotonic.
+    # Align each shootout's render_version with its highest COMPLETE version:
+    # the largest v every chain has a segment for. Per-chain versions are
+    # contiguous 1..n (row_number above), so that is min over chains of the
+    # per-chain max - never the global max, which a single chain's duplicates
+    # would push past versions other chains do not have.
     op.execute(
         """
         UPDATE core_shootouts sh
-        SET render_version = sub.maxv
+        SET render_version = sub.complete_version
         FROM (
-            SELECT sc.shootout_id, max(a.version) AS maxv
-            FROM core_audio_segments a
-            JOIN core_shootout_chains sc ON sc.id = a.shootout_chain_id
+            SELECT sc.shootout_id, min(cmax.maxv) AS complete_version
+            FROM (
+                SELECT shootout_chain_id, max(version) AS maxv
+                FROM core_audio_segments
+                GROUP BY shootout_chain_id
+            ) cmax
+            JOIN core_shootout_chains sc ON sc.id = cmax.shootout_chain_id
             GROUP BY sc.shootout_id
         ) sub
-        WHERE sh.id = sub.shootout_id AND sub.maxv > 1
+        WHERE sh.id = sub.shootout_id AND sub.complete_version > 1
         """
     )
 

--- a/tests/integration/webapp/test_manifest_substrate.py
+++ b/tests/integration/webapp/test_manifest_substrate.py
@@ -1,0 +1,120 @@
+"""Manifest table and versioned substrate properties (ADR-0004, DOM-manifest-table).
+
+Immutability and exactly-once are database properties here, not policed
+behaviour: the unique keys are the invariants the finalise and
+idempotent-consume units build on.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from webapp.adapters.persistence.models.shootout import (
+    AudioSegment,
+    Shootout,
+    ShootoutChain,
+    ShootoutManifest,
+)
+from webapp.adapters.persistence.models.signal_chain import SignalChain
+from webapp.adapters.persistence.models.user import User
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+from gts.domain.value_objects.signal_chain_enums import Platform
+
+
+@pytest.fixture
+async def chain_fixture(db_session: AsyncSession, test_user: User) -> ShootoutChain:
+    shootout = Shootout(id=uuid4(), user_id=test_user.id, name="Substrate Shootout")
+    db_session.add(shootout)
+    signal_chain = SignalChain(user_id=test_user.id, name="SC", platform=Platform.NAM)
+    db_session.add(signal_chain)
+    await db_session.flush()
+    chain = ShootoutChain(
+        id=uuid4(),
+        shootout_id=shootout.id,
+        signal_chain_id=signal_chain.id,
+        position=0,
+        label="A",
+    )
+    db_session.add(chain)
+    await db_session.flush()
+    return chain
+
+
+def _segment(chain_id, version: int) -> AudioSegment:
+    return AudioSegment(
+        shootout_chain_id=chain_id,
+        file_path=f"/app/storage/audio/x/v{version}/seg.wav",
+        duration_seconds=1.0,
+        integrated_lufs=-14.0,
+        peak_dbfs=-1.0,
+        version=version,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestVersionedSubstrate:
+    async def test_duplicate_segment_version_is_rejected(
+        self, db_session: AsyncSession, chain_fixture: ShootoutChain
+    ) -> None:
+        """The pre-fix redelivery shape - two segments for one chain+version - is now impossible."""
+        db_session.add(_segment(chain_fixture.id, 1))
+        await db_session.flush()
+        db_session.add(_segment(chain_fixture.id, 1))
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+        await db_session.rollback()
+
+    async def test_distinct_versions_coexist(
+        self, db_session: AsyncSession, chain_fixture: ShootoutChain
+    ) -> None:
+        db_session.add(_segment(chain_fixture.id, 1))
+        db_session.add(_segment(chain_fixture.id, 2))
+        await db_session.flush()
+
+    async def test_shootout_render_version_defaults_to_one(
+        self, db_session: AsyncSession, test_user: User
+    ) -> None:
+        shootout = Shootout(id=uuid4(), user_id=test_user.id, name="Fresh")
+        db_session.add(shootout)
+        await db_session.flush()
+        assert shootout.render_version == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestManifestTable:
+    async def test_manifest_unique_per_shootout_version(
+        self, db_session: AsyncSession, test_user: User
+    ) -> None:
+        """(shootout_id, version) uniqueness is the finalise exactly-once backstop."""
+        shootout = Shootout(id=uuid4(), user_id=test_user.id, name="Manifested")
+        db_session.add(shootout)
+        await db_session.flush()
+
+        db_session.add(ShootoutManifest(shootout_id=shootout.id, version=1, payload={"chains": []}))
+        await db_session.flush()
+        db_session.add(ShootoutManifest(shootout_id=shootout.id, version=1, payload={"chains": []}))
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+        await db_session.rollback()
+
+    async def test_manifest_defaults(self, db_session: AsyncSession, test_user: User) -> None:
+        shootout = Shootout(id=uuid4(), user_id=test_user.id, name="Defaulted")
+        db_session.add(shootout)
+        await db_session.flush()
+
+        manifest = ShootoutManifest(shootout_id=shootout.id, version=1, payload={"chains": []})
+        db_session.add(manifest)
+        await db_session.flush()
+        await db_session.refresh(manifest)
+
+        assert manifest.schema_version == 1
+        assert manifest.created_at is not None


### PR DESCRIPTION
DOM-manifest-table from the job-reliability cluster (decision: ADR-0004; payload schema: docs/design/shootout-artefact-contract.md).

- Insert-only core_shootout_manifests: unique (shootout_id, version), schema_version default 1, JSONB payload, FK-cascade delete only (unpublish-by-delete). No application update/delete path.
- Versioned substrate: Shootout.render_version (first run = 1; the rerun increment lands with DOM-rerun-versioning), AudioSegment.version + unique (shootout_chain_id, version) - the segment idempotency key JOB-idempotent-consume upserts on.
- Media path convention: renders write only inside STORAGE_BASE/<shootout_id>/v<N>/; the master concatenation pins segments by this run's version instead of the post-rerun-undefined segments[0].
- Migration 0019 handles the adversarial pre-fix shape: existing duplicate segments per chain are numbered by insertion order (UUIDv7 time-ordering) before the unique constraint lands; shootout render_version aligned to the highest segment version.
- Tests: duplicate (chain, version) rejected; distinct versions coexist; manifest exactly-once unique key; defaults.

Gate: full worktree gate green (fresh DB migrated through 0019).