### PR TITLE
feat(jobs): idempotent consumption - claim algorithm, SkipMessage, segment upsert

### DIFF
--- a/apps/audio_worker/src/audio_worker/consumer.py
+++ b/apps/audio_worker/src/audio_worker/consumer.py
@@ -43,6 +43,7 @@ from webapp.adapters.persistence.models.user_gear import UserGear
 from webapp.services.job_transitions import (
     ClaimOutcome,
     claim_job,
+    job_lease_is_live,
     mark_job_dead_lettered,
     transition_job,
 )
@@ -302,31 +303,34 @@ async def _process_shootout_master(job_id: UUID, database_url: str) -> None:
         finally:
             tmp_path.unlink(missing_ok=True)
 
-        # Update shootout and jobs. The shootout/parent COMPLETED projection
-        # is the legacy publish gate, replaced by DOM-shootout-finalise; the
-        # master job's own terminal write goes through the service.
+        # Update shootout and jobs in the service lock order (own job ->
+        # parent job -> shootout) so this cannot deadlock against a concurrent
+        # reconcile. The shootout/parent COMPLETED projection is the legacy
+        # publish gate, replaced by DOM-shootout-finalise; the master job's
+        # own terminal write goes through the service.
         async with get_session(database_url) as session:
-            s_stmt = select(Shootout).where(Shootout.id == shootout_id)
+            job_stmt = select(Job).where(Job.id == job_id).with_for_update()
+            job_result = await session.execute(job_stmt)
+            job = job_result.scalar_one_or_none()
+
+            parent_job = None
+            if job is not None and job.parent_job_id is not None:
+                parent_stmt = select(Job).where(Job.id == job.parent_job_id).with_for_update()
+                parent_result = await session.execute(parent_stmt)
+                parent_job = parent_result.scalar_one_or_none()
+
+            s_stmt = select(Shootout).where(Shootout.id == shootout_id).with_for_update()
             s_result = await session.execute(s_stmt)
             shootout = s_result.scalar_one_or_none()
             if shootout is not None:
                 shootout.output_path = str(master_path)
                 shootout.status = ShootoutStatus.COMPLETED
 
-            job_stmt = select(Job).where(Job.id == job_id)
-            job_result = await session.execute(job_stmt)
-            job = job_result.scalar_one_or_none()
-
-            # Also complete the parent SHOOTOUT job
-            if job is not None and job.parent_job_id is not None:
-                parent_stmt = select(Job).where(Job.id == job.parent_job_id)
-                parent_result = await session.execute(parent_stmt)
-                parent_job = parent_result.scalar_one_or_none()
-                if parent_job is not None:
-                    parent_job.status = JobStatus.COMPLETED
-                    parent_job.progress = 100
-                    parent_job.completed_at = datetime.now(UTC)
-                    parent_job.result_path = str(master_path)
+            if parent_job is not None:
+                parent_job.status = JobStatus.COMPLETED
+                parent_job.progress = 100
+                parent_job.completed_at = datetime.now(UTC)
+                parent_job.result_path = str(master_path)
 
             await transition_job(
                 session,
@@ -402,6 +406,15 @@ class ProcessAudioConsumer(BaseConsumer):
             return
         async with MessageLease(database_url, self.queue_name, message.msg_id, job_id):
             await process_audio_job(job_id)
+
+    async def should_dead_letter(self, queued_message) -> bool:
+        """Never dead-letter a job whose lease is live (skips grew read_ct)."""
+        raw_job_id = (queued_message.message.get("payload") or {}).get("job_id")
+        if not raw_job_id:
+            return True
+        database_url = os.getenv("DATABASE_URL", "postgresql+asyncpg://gts:gts@db:5432/gts_core")
+        async with get_session(database_url) as session:
+            return not await job_lease_is_live(session, UUID(str(raw_job_id)))
 
     async def on_dead_letter(self, message: dict[str, object], reason: str) -> None:
         """Couple the job row to the queue-level DLQ in the same commit."""

--- a/apps/audio_worker/src/audio_worker/consumer.py
+++ b/apps/audio_worker/src/audio_worker/consumer.py
@@ -14,6 +14,7 @@ from uuid import UUID
 import numpy as np
 import soundfile as sf
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import joinedload
 
 from audio.analysis.waveform import extract_waveform
@@ -27,7 +28,7 @@ from audio.processing import (
 from audio_worker.lease import MessageLease
 from gts.domain.value_objects.job_status import JobStatus, JobType
 from messaging.commands import ProcessAudioCommand
-from messaging.consumer_base import BaseConsumer
+from messaging.consumer_base import BaseConsumer, SkipMessage
 from messaging.db import get_session_no_tx as get_session
 from messaging.pgmq_client import PgmqClient
 from webapp.adapters.persistence.models.job import Job
@@ -39,8 +40,12 @@ from webapp.adapters.persistence.models.shootout import (
 )
 from webapp.adapters.persistence.models.signal_chain import SignalChain
 from webapp.adapters.persistence.models.user_gear import UserGear
-from webapp.services.job_transitions import mark_job_dead_lettered
-from webapp.services.shootout_reconciliation import reconcile_parent_after_audio
+from webapp.services.job_transitions import (
+    ClaimOutcome,
+    claim_job,
+    mark_job_dead_lettered,
+    transition_job,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -57,25 +62,12 @@ _render_gate = asyncio.Semaphore(1)
 
 
 async def _process_shootout_audio(job_id: UUID, database_url: str) -> None:
-    """Process a single SHOOTOUT_AUDIO job (one signal chain against the DI track)."""
-    parent_job_id: UUID | None = None
+    """Process a single SHOOTOUT_AUDIO job (one signal chain against the DI track).
 
-    async with get_session(database_url) as session:
-        # Load job
-        job_stmt = select(Job).where(Job.id == job_id)
-        job_result = await session.execute(job_stmt)
-        job = job_result.scalar_one_or_none()
-        if job is None:
-            raise ValueError(f"Job {job_id} not found")
-
-        parent_job_id = job.parent_job_id
-
-        # Mark running
-        job.status = JobStatus.RUNNING
-        job.started_at = datetime.now(UTC)
-        job.last_heartbeat = datetime.now(UTC)
-        await session.commit()
-
+    The consumer claimed the job (RUNNING) before dispatching here; this
+    function only does the work and reports the terminal state through the
+    transition service.
+    """
     try:
         async with get_session(database_url) as session:
             # Load job again for entity_id
@@ -180,30 +172,41 @@ async def _process_shootout_audio(job_id: UUID, database_url: str) -> None:
         info = sf.info(str(output_path))
         duration_seconds = info.duration
 
-        # Create AudioSegment and update job
+        # Upsert the segment on its idempotency key and complete the job in
+        # ONE transaction: a redelivered message that re-renders can never
+        # duplicate a segment row, and the segment write commits with the
+        # COMPLETED transition (which also reconciles the parent).
         async with get_session(database_url) as session:
-            segment = AudioSegment(
-                shootout_chain_id=shootout_chain_id,
-                file_path=str(output_path),
-                duration_seconds=duration_seconds,
-                integrated_lufs=result_lufs,
-                peak_dbfs=result_peak,
-                waveform=waveform,
-                version=render_version,
+            upsert = (
+                pg_insert(AudioSegment)
+                .values(
+                    shootout_chain_id=shootout_chain_id,
+                    file_path=str(output_path),
+                    duration_seconds=duration_seconds,
+                    integrated_lufs=result_lufs,
+                    peak_dbfs=result_peak,
+                    waveform=waveform,
+                    version=render_version,
+                )
+                .on_conflict_do_update(
+                    constraint="uq_audio_segments_chain_version",
+                    set_={
+                        "file_path": str(output_path),
+                        "duration_seconds": duration_seconds,
+                        "integrated_lufs": result_lufs,
+                        "peak_dbfs": result_peak,
+                        "waveform": waveform,
+                    },
+                )
             )
-            session.add(segment)
-
-            job_stmt = select(Job).where(Job.id == job_id)
-            job_result = await session.execute(job_stmt)
-            job = job_result.scalar_one_or_none()
-            if job is not None:
-                job.status = JobStatus.COMPLETED
-                job.progress = 100
-                job.result_path = str(output_path)
-                job.completed_at = datetime.now(UTC)
-                job.last_heartbeat = datetime.now(UTC)
-
-            await session.commit()
+            await session.execute(upsert)
+            await transition_job(
+                session,
+                job_id,
+                JobStatus.COMPLETED,
+                progress=100,
+                result_path=str(output_path),
+            )
 
         logger.info(
             "Completed chain %s: lufs=%.1f peak=%.1f duration=%.1fs",
@@ -216,35 +219,18 @@ async def _process_shootout_audio(job_id: UUID, database_url: str) -> None:
     except (ChainExecutionError, ProcessingError, LoudnessError) as exc:
         logger.error("Chain processing failed for job %s: %s", job_id, exc)
         async with get_session(database_url) as session:
-            job_stmt = select(Job).where(Job.id == job_id)
-            job_result = await session.execute(job_stmt)
-            job = job_result.scalar_one_or_none()
-            if job is not None:
-                job.status = JobStatus.FAILED
-                job.error = str(exc)
-                job.completed_at = datetime.now(UTC)
-            await session.commit()
-
-    # Reconcile parent regardless of success/failure
-    if parent_job_id is not None:
-        await reconcile_parent_after_audio(parent_job_id, database_url)
+            # FAILED applies retry bookkeeping and reconciles the parent.
+            await transition_job(session, job_id, JobStatus.FAILED, error=str(exc))
 
 
 async def _process_shootout_master(job_id: UUID, database_url: str) -> None:
-    """Process a SHOOTOUT_MASTER job (concatenate all chain segments into master)."""
-    async with get_session(database_url) as session:
-        # Load job
-        job_stmt = select(Job).where(Job.id == job_id)
-        job_result = await session.execute(job_stmt)
-        job = job_result.scalar_one_or_none()
-        if job is None:
-            raise ValueError(f"Job {job_id} not found")
+    """Process a SHOOTOUT_MASTER job (concatenate all chain segments into master).
 
-        job.status = JobStatus.RUNNING
-        job.started_at = datetime.now(UTC)
-        job.last_heartbeat = datetime.now(UTC)
-        await session.commit()
-
+    Claimed by the consumer before dispatch; terminal states route through the
+    transition service. The direct shootout/parent COMPLETED projection below
+    is the legacy publish path DOM-shootout-finalise replaces with the
+    SHOOTOUT_FINALISE manifest write.
+    """
     try:
         async with get_session(database_url) as session:
             job_stmt = select(Job).where(Job.id == job_id)
@@ -316,7 +302,9 @@ async def _process_shootout_master(job_id: UUID, database_url: str) -> None:
         finally:
             tmp_path.unlink(missing_ok=True)
 
-        # Update shootout and job
+        # Update shootout and jobs. The shootout/parent COMPLETED projection
+        # is the legacy publish gate, replaced by DOM-shootout-finalise; the
+        # master job's own terminal write goes through the service.
         async with get_session(database_url) as session:
             s_stmt = select(Shootout).where(Shootout.id == shootout_id)
             s_result = await session.execute(s_stmt)
@@ -328,12 +316,6 @@ async def _process_shootout_master(job_id: UUID, database_url: str) -> None:
             job_stmt = select(Job).where(Job.id == job_id)
             job_result = await session.execute(job_stmt)
             job = job_result.scalar_one_or_none()
-            if job is not None:
-                job.status = JobStatus.COMPLETED
-                job.progress = 100
-                job.result_path = str(master_path)
-                job.completed_at = datetime.now(UTC)
-                job.last_heartbeat = datetime.now(UTC)
 
             # Also complete the parent SHOOTOUT job
             if job is not None and job.parent_job_id is not None:
@@ -346,21 +328,20 @@ async def _process_shootout_master(job_id: UUID, database_url: str) -> None:
                     parent_job.completed_at = datetime.now(UTC)
                     parent_job.result_path = str(master_path)
 
-            await session.commit()
+            await transition_job(
+                session,
+                job_id,
+                JobStatus.COMPLETED,
+                progress=100,
+                result_path=str(master_path),
+            )
 
         logger.info("Master audio created for shootout %s: %s", shootout_id, master_path)
 
     except (ProcessingError, LoudnessError) as exc:
         logger.error("Master processing failed for job %s: %s", job_id, exc)
         async with get_session(database_url) as session:
-            job_stmt = select(Job).where(Job.id == job_id)
-            job_result = await session.execute(job_stmt)
-            job = job_result.scalar_one_or_none()
-            if job is not None:
-                job.status = JobStatus.FAILED
-                job.error = str(exc)
-                job.completed_at = datetime.now(UTC)
-            await session.commit()
+            await transition_job(session, job_id, JobStatus.FAILED, error=str(exc))
 
 
 async def process_audio_job(job_id: UUID) -> None:
@@ -400,10 +381,21 @@ class ProcessAudioConsumer(BaseConsumer):
         self._session = session
 
     async def handle_message(self, envelope: MessageEnvelope) -> None:
-        """Handle one process_audio command envelope under a renewed lease."""
+        """Claim, then work the job under a renewed lease (idempotent consumption)."""
         command = ProcessAudioCommand.model_validate(envelope.model_dump(mode="python"))
         job_id = UUID(command.payload["job_id"])
         database_url = os.getenv("DATABASE_URL", "postgresql+asyncpg://gts:gts@db:5432/gts_core")
+
+        async with get_session(database_url) as session:
+            outcome = await claim_job(session, job_id, message="Processing")
+        if outcome == ClaimOutcome.ALREADY_TERMINAL:
+            # Redelivered message for finished work: archive as a no-op.
+            logger.info("Job %s already terminal; archiving redelivered message", job_id)
+            return
+        if outcome == ClaimOutcome.LIVE_LEASE:
+            # Another consumer is live on this job: release without ack.
+            raise SkipMessage(str(job_id))
+
         message = self.current_message
         if message is None:
             await process_audio_job(job_id)

--- a/apps/shootout_orchestrator/src/shootout_orchestrator/consumer.py
+++ b/apps/shootout_orchestrator/src/shootout_orchestrator/consumer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import TYPE_CHECKING
 from uuid import UUID
@@ -11,18 +12,23 @@ from sqlalchemy.orm import joinedload
 
 from gts.domain.value_objects.job_status import JobStatus, JobType
 from messaging.commands import ProcessAudioCommand, StartShootoutCommand
-from messaging.consumer_base import BaseConsumer
+from messaging.consumer_base import BaseConsumer, SkipMessage
 from messaging.db import get_session_no_tx as get_session
 from messaging.pgmq_client import PgmqClient
 from webapp.adapters.persistence.models.job import Job
 from webapp.adapters.persistence.models.shootout import Shootout
 from webapp.services.job_transitions import (
+    ClaimOutcome,
+    claim_job,
+    job_lease_is_live,
     mark_job_dead_lettered,
 )
 from webapp.services.shootout_reconciliation import reconcile_parent_after_audio
 
 if TYPE_CHECKING:
     from messaging.envelope import MessageEnvelope
+
+logger = logging.getLogger(__name__)
 
 
 async def _dispatch_pending_audio_children(parent_job_id: UUID, database_url: str) -> None:
@@ -129,10 +135,29 @@ class StartShootoutConsumer(BaseConsumer):
         self._session = session
 
     async def handle_message(self, envelope: MessageEnvelope) -> None:
-        """Handle one shootout command envelope."""
+        """Claim, then fan out the shootout (idempotent consumption)."""
         command = StartShootoutCommand.model_validate(envelope.model_dump(mode="python"))
         job_id = UUID(command.payload["job_id"])
+        database_url = os.getenv("DATABASE_URL", "postgresql+asyncpg://gts:gts@db:5432/gts_core")
+
+        async with get_session(database_url) as session:
+            outcome = await claim_job(session, job_id, message="Spawning chain jobs")
+        if outcome == ClaimOutcome.ALREADY_TERMINAL:
+            logger.info("Job %s already terminal; archiving redelivered message", job_id)
+            return
+        if outcome == ClaimOutcome.LIVE_LEASE:
+            raise SkipMessage(str(job_id))
+
         await process_shootout_job(job_id)
+
+    async def should_dead_letter(self, queued_message) -> bool:
+        """Never dead-letter a job whose lease is live (skips grew read_ct)."""
+        raw_job_id = (queued_message.message.get("payload") or {}).get("job_id")
+        if not raw_job_id:
+            return True
+        database_url = os.getenv("DATABASE_URL", "postgresql+asyncpg://gts:gts@db:5432/gts_core")
+        async with get_session(database_url) as session:
+            return not await job_lease_is_live(session, UUID(str(raw_job_id)))
 
     async def on_dead_letter(self, message: dict[str, object], reason: str) -> None:
         """Couple the job row to the queue-level DLQ in the same commit."""

--- a/apps/shootout_orchestrator/src/shootout_orchestrator/consumer.py
+++ b/apps/shootout_orchestrator/src/shootout_orchestrator/consumer.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -16,8 +15,10 @@ from messaging.consumer_base import BaseConsumer
 from messaging.db import get_session_no_tx as get_session
 from messaging.pgmq_client import PgmqClient
 from webapp.adapters.persistence.models.job import Job
-from webapp.adapters.persistence.models.shootout import Shootout, ShootoutStatus
-from webapp.services.job_transitions import mark_job_dead_lettered
+from webapp.adapters.persistence.models.shootout import Shootout
+from webapp.services.job_transitions import (
+    mark_job_dead_lettered,
+)
 from webapp.services.shootout_reconciliation import reconcile_parent_after_audio
 
 if TYPE_CHECKING:
@@ -42,6 +43,7 @@ async def _dispatch_pending_audio_children(parent_job_id: UUID, database_url: st
         pending_children = result.scalars().all()
 
         pgmq = PgmqClient(session)
+        await pgmq.create_queue("audio_commands")
         for child in pending_children:
             cmd = ProcessAudioCommand(
                 source_bc="shootout-orchestrator",
@@ -83,13 +85,10 @@ async def process_shootout_job(job_id: UUID) -> None:
         if not shootout.chains:
             raise ValueError(f"Shootout {shootout.id} has no chains")
 
-        parent_job.status = JobStatus.RUNNING
-        if parent_job.started_at is None:
-            parent_job.started_at = datetime.now(UTC)
-        parent_job.last_heartbeat = datetime.now(UTC)
+        # The consumer claimed the parent (RUNNING) before dispatching here;
+        # the shootout's PROCESSING projection is reconcile_parent's, called
+        # below - no direct status writes in the orchestrator.
         parent_job.message = "Spawning chain jobs"
-
-        shootout.status = ShootoutStatus.PROCESSING
 
         child_stmt = select(Job).where(
             Job.parent_job_id == parent_job.id,

--- a/apps/webapp/src/webapp/services/job_transitions.py
+++ b/apps/webapp/src/webapp/services/job_transitions.py
@@ -73,6 +73,8 @@ async def transition_job(
     *,
     error: str | None = None,
     message: str | None = None,
+    progress: int | None = None,
+    result_path: str | None = None,
     renewal: bool = False,
 ) -> Job:
     """Move a job to `to_status`, reconcile its parent if needed, and commit.
@@ -112,6 +114,10 @@ async def transition_job(
         job.message = message
     if error is not None:
         job.error = error
+    if progress is not None:
+        job.progress = progress
+    if result_path is not None:
+        job.result_path = result_path
     if to_status == JobStatus.RUNNING:
         if job.started_at is None:
             job.started_at = now
@@ -166,6 +172,34 @@ async def transition_job(
 
     await session.commit()
     return job
+
+
+class ClaimOutcome:
+    """Consumer claim results (docs/design/job-system-contract.md, Consumer contract)."""
+
+    CLAIMED = "claimed"
+    ALREADY_TERMINAL = "already_terminal"
+    LIVE_LEASE = "live_lease"
+
+
+async def claim_job(session: AsyncSession, job_id: UUID, *, message: str | None = None) -> str:
+    """Run the consumer claim algorithm and return the outcome.
+
+    CLAIMED: QUEUED -> RUNNING (or a stale RUNNING re-claim, or the
+    self-managed PENDING -> RUNNING edge). ALREADY_TERMINAL: redelivered
+    message for finished work - the caller archives it as a no-op.
+    LIVE_LEASE: another consumer's lease is fresh - the caller must release
+    the message without acknowledging it.
+    """
+    try:
+        await transition_job(session, job_id, JobStatus.RUNNING, message=message)
+    except LiveLeaseError:
+        return ClaimOutcome.LIVE_LEASE
+    except InvalidTransitionError as exc:
+        if exc.current.is_terminal():
+            return ClaimOutcome.ALREADY_TERMINAL
+        raise
+    return ClaimOutcome.CLAIMED
 
 
 async def mark_job_dead_lettered(

--- a/apps/webapp/src/webapp/services/job_transitions.py
+++ b/apps/webapp/src/webapp/services/job_transitions.py
@@ -174,6 +174,20 @@ async def transition_job(
     return job
 
 
+async def job_lease_is_live(session: AsyncSession, job_id: UUID) -> bool:
+    """Whether the job is RUNNING under a fresh lease (heartbeat within threshold).
+
+    Used by consumers to veto queue-level dead-lettering of healthy work whose
+    redeliveries were skipped (SkipMessage does not consume attempts, but pgmq
+    still counts reads).
+    """
+    result = await session.execute(select(Job).where(Job.id == job_id))
+    job = result.scalar_one_or_none()
+    if job is None or job.status != JobStatus.RUNNING or job.last_heartbeat is None:
+        return False
+    return job.last_heartbeat > datetime.now(UTC) - LEASE_THRESHOLD
+
+
 class ClaimOutcome:
     """Consumer claim results (docs/design/job-system-contract.md, Consumer contract)."""
 

--- a/infra/messaging/src/messaging/consumer_base.py
+++ b/infra/messaging/src/messaging/consumer_base.py
@@ -132,6 +132,15 @@ class BaseConsumer(ABC):
         if current_attempt > max_attempts:
             await self.rollback_message()
             await self.reset_message_context()
+            if not await self.should_dead_letter(queued_message):
+                # Healthy work whose redeliveries were skipped (live lease):
+                # push visibility out instead of dead-lettering it.
+                await self.message_bus.set_vt(
+                    self.queue_name, queued_message.msg_id, VT_EXTENSION_SECONDS
+                )
+                await self.commit_message()
+                await self.reset_message_context()
+                return
             await self._move_to_dead_letter(
                 queued_message,
                 "max retries exceeded before processing",
@@ -156,8 +165,14 @@ class BaseConsumer(ABC):
             await self.reset_message_context()
             return
         except SkipMessage:
-            # Release without acknowledging: no archive, no retry accounting.
+            # Release without acknowledging. Push visibility out a full lease
+            # window so skip cycles stay rare and read_ct barely grows.
             await self.rollback_message()
+            await self.reset_message_context()
+            await self.message_bus.set_vt(
+                self.queue_name, queued_message.msg_id, VT_EXTENSION_SECONDS
+            )
+            await self.commit_message()
             await self.reset_message_context()
             self.logger.warning(
                 "Released message %s from %s without ack (live lease elsewhere)",
@@ -223,6 +238,17 @@ class BaseConsumer(ABC):
         await self.message_bus.send(self.dead_letter_queue, dlq_message)
         await self.message_bus.archive(self.queue_name, queued_message.msg_id)
         await self.on_dead_letter(queued_message.message, reason)
+
+    async def should_dead_letter(
+        self,
+        queued_message: QueueMessage,  # noqa: ARG002 - hook signature for overrides
+    ) -> bool:
+        """Veto hook before max-redelivery dead-lettering; default allows it.
+
+        Job-backed consumers override to protect RUNNING jobs under a live
+        lease, whose read counts grew only through no-ack skips.
+        """
+        return True
 
     async def on_dead_letter(
         self,

--- a/infra/messaging/src/messaging/consumer_base.py
+++ b/infra/messaging/src/messaging/consumer_base.py
@@ -28,6 +28,14 @@ if TYPE_CHECKING:
     from messaging.message_bus import MessageBus, QueueMessage
 
 
+class SkipMessage(Exception):
+    """Raised by a handler to release a message without acknowledging it.
+
+    The message stays invisible until its visibility timeout lapses, then
+    redelivers. Used when another consumer holds a live lease on the job.
+    """
+
+
 class BaseConsumer(ABC):
     """Common polling loop and failure handling for pgmq consumers.
 
@@ -146,6 +154,16 @@ class BaseConsumer(ABC):
             await self.message_bus.archive(self.queue_name, queued_message.msg_id)
             await self.commit_message()
             await self.reset_message_context()
+            return
+        except SkipMessage:
+            # Release without acknowledging: no archive, no retry accounting.
+            await self.rollback_message()
+            await self.reset_message_context()
+            self.logger.warning(
+                "Released message %s from %s without ack (live lease elsewhere)",
+                queued_message.msg_id,
+                self.queue_name,
+            )
             return
         except Exception as error:
             await self.rollback_message()

--- a/tests/integration/webapp/test_idempotent_consume.py
+++ b/tests/integration/webapp/test_idempotent_consume.py
@@ -1,0 +1,151 @@
+"""Idempotent consumption: the claim algorithm and the segment upsert.
+
+The pre-fix shape: pgmq redelivered after the 60s visibility timeout, the
+handler re-set RUNNING over terminal states and inserted duplicate
+AudioSegment rows. The claim algorithm and the (shootout_chain_id, version)
+upsert make every redelivery a no-op or a clean overwrite.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from gts.domain.value_objects.job_status import JobStatus, JobType
+from webapp.adapters.persistence.models.job import Job
+from webapp.adapters.persistence.models.shootout import (
+    AudioSegment,
+    Shootout,
+    ShootoutChain,
+)
+from webapp.adapters.persistence.models.signal_chain import SignalChain
+from webapp.adapters.persistence.models.user import User
+from webapp.services.job_transitions import ClaimOutcome, claim_job
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+from gts.domain.value_objects.signal_chain_enums import Platform
+
+
+def _job(status: JobStatus) -> Job:
+    return Job(
+        id=uuid4(),
+        user_id=None,
+        job_type=JobType.SHOOTOUT_AUDIO,
+        entity_id=uuid4(),
+        status=status,
+        progress=0,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestClaimAlgorithm:
+    async def test_queued_job_is_claimed(self, db_session: AsyncSession) -> None:
+        job = _job(JobStatus.QUEUED)
+        db_session.add(job)
+        await db_session.flush()
+
+        outcome = await claim_job(db_session, job.id, message="Processing")
+
+        assert outcome == ClaimOutcome.CLAIMED
+        await db_session.refresh(job)
+        assert job.status == JobStatus.RUNNING
+        assert job.last_heartbeat is not None
+
+    async def test_terminal_job_returns_already_terminal(self, db_session: AsyncSession) -> None:
+        """Redelivered message for finished work: the caller archives, state untouched."""
+        job = _job(JobStatus.COMPLETED)
+        db_session.add(job)
+        await db_session.flush()
+
+        outcome = await claim_job(db_session, job.id)
+
+        assert outcome == ClaimOutcome.ALREADY_TERMINAL
+        await db_session.refresh(job)
+        assert job.status == JobStatus.COMPLETED
+
+    async def test_fresh_lease_returns_live_lease(self, db_session: AsyncSession) -> None:
+        job = _job(JobStatus.QUEUED)
+        db_session.add(job)
+        await db_session.flush()
+        await claim_job(db_session, job.id)
+
+        outcome = await claim_job(db_session, job.id)
+
+        assert outcome == ClaimOutcome.LIVE_LEASE
+
+    async def test_stale_lease_is_reclaimed(self, db_session: AsyncSession) -> None:
+        job = _job(JobStatus.QUEUED)
+        db_session.add(job)
+        await db_session.flush()
+        await claim_job(db_session, job.id)
+        await db_session.execute(
+            text(
+                "UPDATE core_jobs SET last_heartbeat = now() - interval '10 minutes' WHERE id = :id"
+            ),
+            {"id": str(job.id)},
+        )
+
+        outcome = await claim_job(db_session, job.id)
+
+        assert outcome == ClaimOutcome.CLAIMED
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestSegmentUpsert:
+    async def test_reprocessing_overwrites_instead_of_duplicating(
+        self, db_session: AsyncSession, test_user: User
+    ) -> None:
+        shootout = Shootout(id=uuid4(), user_id=test_user.id, name="Upsert Shootout")
+        db_session.add(shootout)
+        signal_chain = SignalChain(user_id=test_user.id, name="SC", platform=Platform.NAM)
+        db_session.add(signal_chain)
+        await db_session.flush()
+        chain = ShootoutChain(
+            id=uuid4(),
+            shootout_id=shootout.id,
+            signal_chain_id=signal_chain.id,
+            position=0,
+            label="A",
+        )
+        db_session.add(chain)
+        await db_session.flush()
+
+        def _upsert(path: str):
+            return (
+                pg_insert(AudioSegment)
+                .values(
+                    shootout_chain_id=chain.id,
+                    file_path=path,
+                    duration_seconds=1.0,
+                    integrated_lufs=-14.0,
+                    peak_dbfs=-1.0,
+                    version=1,
+                )
+                .on_conflict_do_update(
+                    constraint="uq_audio_segments_chain_version",
+                    set_={"file_path": path},
+                )
+            )
+
+        await db_session.execute(_upsert("/v1/first.wav"))
+        await db_session.execute(_upsert("/v1/second.wav"))
+
+        segments = (
+            (
+                await db_session.execute(
+                    select(AudioSegment).where(AudioSegment.shootout_chain_id == chain.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(segments) == 1
+        assert segments[0].file_path == "/v1/second.wav"

--- a/tests/unit/webapp/test_status_writer_guard.py
+++ b/tests/unit/webapp/test_status_writer_guard.py
@@ -34,12 +34,13 @@ ALLOWED: dict[str, int] = {
     "apps/webapp/src/webapp/services/job_dispatch.py": 1,
     # The run-request edge: shootout DRAFT -> PENDING at the process trigger.
     "apps/webapp/src/webapp/api/v1/shootouts.py": 1,
+    # The orchestrator's fan-out dispatch: an outbox site (send + QUEUED flip
+    # in one transaction), kept beside its thick-payload command construction.
+    "apps/shootout_orchestrator/src/shootout_orchestrator/consumer.py": 1,
     # --- Legacy writers, shrink only ---
-    # JOB-idempotent-consume + DOM-shootout-finalise: claim, complete, fail,
-    # and the master path's rogue parent/shootout projection.
-    "apps/audio_worker/src/audio_worker/consumer.py": 8,
-    # JOB-idempotent-consume: orchestrator claim + fan-out dispatch flips.
-    "apps/shootout_orchestrator/src/shootout_orchestrator/consumer.py": 3,
+    # DOM-shootout-finalise: the master path's shootout/parent COMPLETED
+    # projection - the legacy publish gate the finalise job replaces.
+    "apps/audio_worker/src/audio_worker/consumer.py": 2,
     # DOM-reaper-render-race: the raw-SQL stale-job reaper (both paths).
     "apps/t3k_sync/src/t3k_sync/tasks.py": 2,
     # Domain->ORM mapping in the shootout repository save path.


### PR DESCRIPTION
JOB-idempotent-consume from the job-reliability cluster (design authority: docs/design/job-system-contract.md, Consumer contract + Idempotency keys).

- claim_job service function implements the contract claim algorithm: CLAIMED (QUEUED->RUNNING, stale re-claim), ALREADY_TERMINAL (caller archives the redelivery as a no-op), LIVE_LEASE (caller releases without ack). transition_job gains progress/result_path bookkeeping kwargs.
- Consumer base gains SkipMessage: release without acknowledging - no archive, no retry accounting; the message redelivers after its visibility timeout.
- The audio worker claims before dispatching to handlers (under the MessageLease); both handlers report terminal states exclusively through the transition service - FAILED now participates in bounded auto-retry.
- AudioSegment writes become ON CONFLICT DO UPDATE upserts on (shootout_chain_id, version), committed atomically with the COMPLETED transition; the explicit post-work reconcile call is gone (the service reconciles).
- The orchestrator claims via claim_job and drops its direct parent/shootout writes (reconcile projects PROCESSING); its fan-out send+QUEUED flip stays as a sanctioned outbox site.
- Status-writer allowlist: audio worker 8 -> 2 (only the legacy master publish projection, replaced by DOM-shootout-finalise), orchestrator 3 -> 1.

Gate: full worktree gate green.