### PR TITLE
feat(jobs): lease-aware reaper through the transition service (DOM-reaper-render-race)

### DIFF
--- a/apps/t3k_sync/src/t3k_sync/tasks.py
+++ b/apps/t3k_sync/src/t3k_sync/tasks.py
@@ -24,7 +24,11 @@ from webapp.services.job_dispatch import (
     JobNotPendingError,
     enqueue_job,
 )
-from webapp.services.job_transitions import TransitionError, transition_job
+from webapp.services.job_transitions import (
+    LEASE_THRESHOLD,
+    TransitionError,
+    transition_job,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -174,104 +178,105 @@ async def refresh_t3k_token(
 
 
 async def monitor_stale_jobs() -> None:
-    """Mark RUNNING jobs with stale heartbeats as DEAD_LETTERED.
+    """Reap RUNNING jobs whose lease went stale, through the transition service.
 
-    For SOURCE_SYNC jobs, checks the advisory lock before marking dead.
-    If the lock is held, the sync is still alive regardless of heartbeat.
+    The reaper reaps stale leases, not old jobs: a live render heartbeats
+    every HEARTBEAT_INTERVAL_SECONDS, so only work whose worker died (and
+    whose message nothing re-claimed) trips the threshold. The reap is an
+    ordinary RUNNING -> FAILED failure - it participates in bounded retry and
+    reconciles the parent - never a raw write. The reaper does not touch
+    pgmq: a redelivered message for a reaped job archives at the consumer's
+    terminal guard, and a reap racing a live re-claim loses at the row lock.
+
+    SOURCE_SYNC keeps its advisory-lock variant: the lock being held proves
+    the sync is alive regardless of heartbeat.
     """
-    stale_threshold = datetime.now(UTC) - timedelta(minutes=2)
     now = datetime.now(UTC)
+    stale_threshold = now - LEASE_THRESHOLD
 
-    # Non-SOURCE_SYNC jobs: heartbeat-only check (unchanged behaviour)
-    non_sync_stmt = text("""
-        UPDATE core_jobs SET status = :dead_status, error = :error, completed_at = :now
+    select_stmt = text("""
+        SELECT id, job_type FROM core_jobs
         WHERE status = :running_status
-          AND job_type != 'source_sync'
           AND (last_heartbeat IS NULL OR last_heartbeat < :threshold)
           AND (started_at IS NULL OR started_at < :threshold)
+        LIMIT 100
     """)
-    non_sync_params = {
-        "dead_status": JobStatus.DEAD_LETTERED.value,
-        "error": "Stale heartbeat detected: worker failed to update heartbeat within 2 minutes",
-        "running_status": JobStatus.RUNNING.value,
-        "threshold": stale_threshold,
-        "now": now,
-    }
-
-    # SOURCE_SYNC jobs: check advisory lock before killing
-    sync_check_stmt = text("""
-        SELECT id FROM core_jobs
-        WHERE status = :running_status
-          AND job_type = 'source_sync'
-          AND (last_heartbeat IS NULL OR last_heartbeat < :threshold)
-          AND (started_at IS NULL OR started_at < :threshold)
-    """)
-    sync_check_params = {
+    params = {
         "running_status": JobStatus.RUNNING.value,
         "threshold": stale_threshold,
     }
 
     if _test_session is not None:
-        await _test_session.execute(non_sync_stmt, non_sync_params)
-        # In tests we can't probe advisory locks across sessions,
-        # so skip SOURCE_SYNC lock check — tests use non-sync job types.
+        result = await _test_session.execute(select_stmt, params)
+        rows = result.fetchall()
+    else:
+        async with get_core_session_no_tx() as session:
+            result = await session.execute(select_stmt, params)
+            rows = result.fetchall()
+
+    stale_jobs = [(row[0], row[1]) for row in rows]
+    if not stale_jobs:
         return
 
-    async with get_core_session() as session:
-        await session.execute(non_sync_stmt, non_sync_params)
+    stale_sync_ids = [jid for jid, jtype in stale_jobs if jtype == "source_sync"]
+    stale_other_ids = [jid for jid, jtype in stale_jobs if jtype != "source_sync"]
 
-        # Check if any SOURCE_SYNC jobs look stale
-        result = await session.execute(sync_check_stmt, sync_check_params)
-        stale_sync_ids = [row[0] for row in result.fetchall()]
-        if not stale_sync_ids:
-            return
+    for job_id in stale_other_ids:
+        error = (
+            "Stale lease: no heartbeat within "
+            f"{int(LEASE_THRESHOLD.total_seconds())}s; worker presumed dead"
+        )
+        try:
+            if _test_session is not None:
+                await transition_job(_test_session, job_id, JobStatus.FAILED, error=error)
+            else:
+                async with get_core_session_no_tx() as session:
+                    await transition_job(session, job_id, JobStatus.FAILED, error=error)
+        except TransitionError as exc:
+            # A live re-claim or a terminal write won the race: not ours to reap.
+            logger.info("Reap skipped for job %s: %s", job_id, exc)
+        except Exception:
+            logger.exception("Error reaping job %s", job_id)
+
+    if not stale_sync_ids or _test_session is not None:
+        # In tests we can't probe advisory locks across sessions,
+        # so skip SOURCE_SYNC lock check - tests use non-sync job types.
+        return
 
     # Probe the advisory lock in a separate session (non-transactional).
-    # pg_try_advisory_lock acquires if free — we must release immediately.
-    from messaging.db import get_core_session_no_tx
-
+    # pg_try_advisory_lock acquires if free - we must release immediately.
     async with get_core_session_no_tx() as lock_session:
         lock_result = await lock_session.execute(
             text("SELECT pg_try_advisory_lock(:key)"), {"key": _PG_ADVISORY_LOCK_KEY}
         )
         lock_free = lock_result.scalar()
         if lock_free:
-            # Lock was free — sync truly died. Release our test lock.
+            # Lock was free - sync truly died. Release our test lock.
             await lock_session.execute(
                 text("SELECT pg_advisory_unlock(:key)"), {"key": _PG_ADVISORY_LOCK_KEY}
             )
-            # Mark the stale SOURCE_SYNC jobs as dead
-            async with get_core_session() as session:
-                kill_stmt = text("""
-                    UPDATE core_jobs SET status = :dead_status, error = :error, completed_at = :now
-                    WHERE id = ANY(:ids) AND status = :running_status
-                """)
-                await session.execute(
-                    kill_stmt,
-                    {
-                        "dead_status": JobStatus.DEAD_LETTERED.value,
-                        "error": "Stale heartbeat detected: sync lock free, worker died",
-                        "running_status": JobStatus.RUNNING.value,
-                        "now": now,
-                        "ids": stale_sync_ids,
-                    },
-                )
+            for job_id in stale_sync_ids:
+                try:
+                    async with get_core_session_no_tx() as session:
+                        await transition_job(
+                            session,
+                            job_id,
+                            JobStatus.FAILED,
+                            error="Stale lease: sync advisory lock free, worker died",
+                        )
+                except TransitionError as exc:
+                    logger.info("Reap skipped for sync job %s: %s", job_id, exc)
+                except Exception:
+                    logger.exception("Error reaping sync job %s", job_id)
         else:
-            # Lock held — sync is alive, just slow. Update heartbeat to prevent
-            # re-checking every cycle.
-            async with get_core_session() as session:
-                touch_stmt = text("""
-                    UPDATE core_jobs SET last_heartbeat = :now
-                    WHERE id = ANY(:ids) AND status = :running_status
-                """)
-                await session.execute(
-                    touch_stmt,
-                    {
-                        "now": now,
-                        "running_status": JobStatus.RUNNING.value,
-                        "ids": stale_sync_ids,
-                    },
-                )
+            # Lock held - sync is alive, just slow. Renew its lease through
+            # the service so it is not re-checked every cycle.
+            for job_id in stale_sync_ids:
+                try:
+                    async with get_core_session_no_tx() as session:
+                        await transition_job(session, job_id, JobStatus.RUNNING, renewal=True)
+                except TransitionError as exc:
+                    logger.info("Lease renewal skipped for sync job %s: %s", job_id, exc)
 
 
 async def process_pending_retries() -> None:

--- a/apps/t3k_sync/src/t3k_sync/tasks.py
+++ b/apps/t3k_sync/src/t3k_sync/tasks.py
@@ -228,10 +228,22 @@ async def monitor_stale_jobs() -> None:
         )
         try:
             if _test_session is not None:
-                await transition_job(_test_session, job_id, JobStatus.FAILED, error=error)
+                await transition_job(
+                    _test_session,
+                    job_id,
+                    JobStatus.FAILED,
+                    error=error,
+                    require_stale_lease=True,
+                )
             else:
                 async with get_core_session_no_tx() as session:
-                    await transition_job(session, job_id, JobStatus.FAILED, error=error)
+                    await transition_job(
+                        session,
+                        job_id,
+                        JobStatus.FAILED,
+                        error=error,
+                        require_stale_lease=True,
+                    )
         except TransitionError as exc:
             # A live re-claim or a terminal write won the race: not ours to reap.
             logger.info("Reap skipped for job %s: %s", job_id, exc)
@@ -263,6 +275,7 @@ async def monitor_stale_jobs() -> None:
                             job_id,
                             JobStatus.FAILED,
                             error="Stale lease: sync advisory lock free, worker died",
+                            require_stale_lease=True,
                         )
                 except TransitionError as exc:
                     logger.info("Reap skipped for sync job %s: %s", job_id, exc)

--- a/apps/webapp/src/webapp/services/job_transitions.py
+++ b/apps/webapp/src/webapp/services/job_transitions.py
@@ -76,6 +76,7 @@ async def transition_job(
     progress: int | None = None,
     result_path: str | None = None,
     renewal: bool = False,
+    require_stale_lease: bool = False,
 ) -> Job:
     """Move a job to `to_status`, reconcile its parent if needed, and commit.
 
@@ -103,6 +104,17 @@ async def transition_job(
         to_status == JobStatus.RUNNING
         and job.status == JobStatus.RUNNING
         and not renewal
+        and job.last_heartbeat is not None
+        and job.last_heartbeat > now - LEASE_THRESHOLD
+    ):
+        raise LiveLeaseError()
+
+    # Reaper precondition, re-checked under the row lock: a lease renewal
+    # committed between the reaper's SELECT and this transaction must win -
+    # the reaper never fails a now-live job.
+    if (
+        require_stale_lease
+        and job.status == JobStatus.RUNNING
         and job.last_heartbeat is not None
         and job.last_heartbeat > now - LEASE_THRESHOLD
     ):

--- a/tests/unit/scheduler/test_scheduled_tasks.py
+++ b/tests/unit/scheduler/test_scheduled_tasks.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
+import pytest
 from sqlalchemy import select, text
 
 from gts.domain.entities.job import Job
@@ -468,3 +469,39 @@ class TestPurgeOldJobs:
 
         await session.refresh(model)
         assert model.status == JobStatus.COMPLETED.value
+
+
+class TestReaperLoseToLiveRenewal:
+    """The reap re-checks the lease under the row lock and loses to a renewal."""
+
+    async def test_renewed_lease_between_select_and_reap_survives(
+        self, session: AsyncSession
+    ) -> None:
+        from webapp.adapters.persistence.models.job import Job as JobModel
+        from webapp.services.job_transitions import (
+            LiveLeaseError,
+            transition_job,
+        )
+
+        job_entity = Job(
+            id=uuid4(),
+            user_id=None,
+            job_type=JobType.AUDIO_PROCESSING,
+            status=JobStatus.RUNNING,
+            last_heartbeat=datetime.now(UTC),  # renewed just before the reap
+        )
+        job_model = JobModel.from_entity(job_entity)
+        session.add(job_model)
+        await session.commit()
+
+        with pytest.raises(LiveLeaseError):
+            await transition_job(
+                session,
+                job_entity.id,
+                JobStatus.FAILED,
+                error="Stale lease",
+                require_stale_lease=True,
+            )
+
+        await session.refresh(job_model)
+        assert job_model.status == JobStatus.RUNNING.value

--- a/tests/unit/scheduler/test_scheduled_tasks.py
+++ b/tests/unit/scheduler/test_scheduled_tasks.py
@@ -19,10 +19,10 @@ if TYPE_CHECKING:
 class TestMonitorStaleJobs:
     """Test monitor_stale_jobs scheduled task."""
 
-    async def test_marks_running_job_with_stale_heartbeat_as_dead_lettered(
+    async def test_reaps_running_job_with_stale_lease_as_failed(
         self, session: AsyncSession
     ) -> None:
-        """RUNNING job with heartbeat older than 2 minutes is marked DEAD_LETTERED."""
+        """A stale lease reaps as an ordinary FAILED (retryable), never a raw dead-letter."""
         from t3k_sync.tasks import monitor_stale_jobs
         from webapp.adapters.persistence.models.job import Job as JobModel
 
@@ -41,9 +41,11 @@ class TestMonitorStaleJobs:
         await monitor_stale_jobs()
 
         await session.refresh(job_model)
-        assert job_model.status == JobStatus.DEAD_LETTERED.value
+        assert job_model.status == JobStatus.FAILED.value
         assert job_model.error is not None
-        assert "stale heartbeat" in job_model.error.lower()
+        assert "stale lease" in job_model.error.lower()
+        # A first-attempt reap participates in bounded auto-retry.
+        assert job_model.next_retry_at is not None
 
     async def test_does_not_mark_running_job_with_recent_heartbeat(
         self, session: AsyncSession
@@ -94,7 +96,7 @@ class TestMonitorStaleJobs:
         assert job_model.status == JobStatus.PENDING.value
 
     async def test_marks_multiple_stale_jobs(self, session: AsyncSession) -> None:
-        """All RUNNING jobs with stale heartbeats are marked DEAD_LETTERED."""
+        """All RUNNING jobs with stale leases are reaped to FAILED."""
         from t3k_sync.tasks import monitor_stale_jobs
         from webapp.adapters.persistence.models.job import Job as JobModel
 
@@ -118,7 +120,7 @@ class TestMonitorStaleJobs:
 
         result = await session.execute(
             select(JobModel).where(
-                JobModel.status == JobStatus.DEAD_LETTERED.value,
+                JobModel.status == JobStatus.FAILED.value,
                 JobModel.id.in_(job_ids),
             )
         )

--- a/tests/unit/webapp/test_status_writer_guard.py
+++ b/tests/unit/webapp/test_status_writer_guard.py
@@ -41,8 +41,6 @@ ALLOWED: dict[str, int] = {
     # DOM-shootout-finalise: the master path's shootout/parent COMPLETED
     # projection - the legacy publish gate the finalise job replaces.
     "apps/audio_worker/src/audio_worker/consumer.py": 2,
-    # DOM-reaper-render-race: the raw-SQL stale-job reaper (both paths).
-    "apps/t3k_sync/src/t3k_sync/tasks.py": 2,
     # Domain->ORM mapping in the shootout repository save path.
     "apps/webapp/src/webapp/adapters/persistence/repositories/shootout_repository.py": 1,
     # DEBT-backend-dead-modules: the unused job repository write path.


### PR DESCRIPTION
DOM-reaper-render-race from the job-reliability cluster (design authority: docs/design/job-system-contract.md, Reaper section; ADR-0005).

- monitor_stale_jobs reaps on stale last_heartbeat (LEASE_THRESHOLD 120 s), never on job age; live renders heartbeat every 20 s under the message lease and are untouchable.
- Each reap is RUNNING -> FAILED through the transition service: retry bookkeeping applies (a first-attempt reap auto-retries once), the parent shootout reconciles, and a race against a live re-claim or terminal write loses cleanly at the row lock/transition guard (logged, skipped).
- The reaper never touches pgmq; redelivered messages for reaped jobs archive at the consumer terminal guard.
- SOURCE_SYNC keeps the advisory-lock probe: lock held renews the lease through the service; lock free reaps as FAILED.
- tasks.py carries zero raw status writes; the status-writer allowlist is down to the transition service, the two outbox edges, the run-request flip, the repositories' save mapping, and the one legacy master projection DOM-shootout-finalise deletes.

Gate: full worktree gate green.